### PR TITLE
Add Python 3.7 support and fix Python 3.5 travis build failing test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,20 @@ matrix:
         - python runtests.py 'run_fast()'
         - popd
         - python runtests.py 'exit_tests()'
-    # latest versions, full tests
+    # latest versions, fast tests for python 3.6
     - python: 3.6
+      before_install:
+        - pip install numpy>=1.13 scipy>=1.0 nose>=1.3.7
+      script:
+        - python runtests.py 'setup_tests()'
+        - pushd ./build/tests
+        - python runtests.py 'run_fast()'
+        - popd
+        - python runtests.py 'exit_tests()'
+      after_success:
+        - codecov
+    # latest versions, full tests for python 3.7
+    - python: 3.7
       before_install:
         - pip install numpy>=1.13 scipy>=1.0 nose>=1.3.7
         # - pip install matplotlib>=2.1.0  # needed for quickguide doctests

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ matrix:
         - codecov
     # latest versions, full tests for python 3.7
     - python: 3.7
+      dist: xenial  # see travis-ci/travis-ci/issues/9815
+      sudo: true
       before_install:
         - pip install numpy>=1.13 scipy>=1.0 nose>=1.3.7
         # - pip install matplotlib>=2.1.0  # needed for quickguide doctests

--- a/sdepy/shortcuts.py
+++ b/sdepy/shortcuts.py
@@ -161,7 +161,7 @@ if _config.KFUNC in ('all', 'shortcuts'):
 
     bsd1d2 = kfunc(nvar=2)(bsd1d2)
     bscall = kfunc(nvar=2)(bscall)
-    bscall_dela = kfunc(nvar=2)(bscall_delta)
+    bscall_delta = kfunc(nvar=2)(bscall_delta)
     bsput = kfunc(nvar=2)(bsput)
     bsput_delta = kfunc(nvar=2)(bsput_delta)
 

--- a/sdepy/tests/shared.py
+++ b/sdepy/tests/shared.py
@@ -45,7 +45,7 @@ KFUNC = _config.KFUNC
 
 # exact equality is tested up to the float resolution times EPS_FACTOR
 # (see eps function below)
-EPS_FACTOR = 10
+EPS_FACTOR = 16
 
 # each testing routine should call np.random.seed(SEED)
 SEED = 1234

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ if __name__ == '__main__':
             'Programming Language :: Python :: 3',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7',
             'Topic :: Software Development',
             'Topic :: Scientific/Engineering',
             'Operating System :: OS Independent',


### PR DESCRIPTION
Add python 3.7 support to setup.py and to travis builds: full tests and codecov now run on python 3.7 build, and python 3.6 build was demoted to fast tests only.

Fix failing test for python 3.5 travis build: relative tolerance for machine-precision comparisons in tests increased from 10 to 16 times the floating point epsilon. The failure, which could not be reproduced locally (windows 10 64 bit platform), occurred upon testing that the ``process.interp`` method acts identically when interpolating on the timeline of the calling process.