### PR TITLE
Add a piecewise constant process constructor

### DIFF
--- a/doc/apidoc.rst
+++ b/doc/apidoc.rst
@@ -16,6 +16,7 @@ Infrastructure
    :toctree: generated/
 
    process
+   piecewise
    montecarlo
 
 


### PR DESCRIPTION
Add a piecewise constant process constructor.

Bring sdepy.infrastructure._piecewise_constant_process into the public namespace as sdepy.piecewise, and extend it to cover piecewise constant path dependent processes.