### PR TITLE
Migrate from nose to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     # minimum requirements, fast tests
     - python: 3.5
       before_install:
-        - pip install numpy==1.11.3 scipy==0.18.1 nose==1.3.7
+        - pip install numpy==1.15 scipy==0.19 pytest==3.8
       script:
         - python runtests.py 'setup_tests()'
         - pushd ./build/tests
@@ -22,7 +22,7 @@ matrix:
     # python 3.6, latest versions of other dependencies, fast tests
     - python: 3.6
       before_install:
-        - pip install numpy>=1.16 scipy>=1.2 nose>=1.3.7
+        - pip install numpy>=1.16 scipy>=1.2 pytest>=3.8
       script:
         - python runtests.py 'setup_tests()'
         - pushd ./build/tests
@@ -35,7 +35,7 @@ matrix:
       dist: xenial  # see travis-ci/travis-ci/issues/9815
       sudo: true
       before_install:
-        - pip install numpy>=1.16 scipy>=1.2 nose>=1.3.7
+        - pip install numpy>=1.16 scipy>=1.2 pytest>=3.8
         # - pip install matplotlib>=2.1.0  # needed for quickguide doctests
         - pip install coverage>=4.5.1 codecov>=2.0.15
       script:
@@ -46,4 +46,3 @@ matrix:
         - python runtests.py 'exit_tests()'
       after_success:
         - codecov
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     # minimum requirements, fast tests
     - python: 3.5
       before_install:
-        - pip install numpy==1.15 scipy==0.19 pytest==3.8
+        - pip install numpy==1.15.2 scipy==0.19.1 pytest==3.8.1
       script:
         - python runtests.py 'setup_tests()'
         - pushd ./build/tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     # python 3.6, latest versions of other dependencies, fast tests
     - python: 3.6
       before_install:
-        - pip install numpy>=1.16 scipy>=1.2 pytest>=3.8
+        - pip install numpy>=1.16.2 scipy>=1.2.1 pytest>=3.8.1
       script:
         - python runtests.py 'setup_tests()'
         - pushd ./build/tests
@@ -35,7 +35,7 @@ matrix:
       dist: xenial  # see travis-ci/travis-ci/issues/9815
       sudo: true
       before_install:
-        - pip install numpy>=1.16 scipy>=1.2 pytest>=3.8
+        - pip install numpy>=1.16.2 scipy>=1.2.1 pytest>=3.8.1
         # - pip install matplotlib>=2.1.0  # needed for quickguide doctests
         - pip install coverage>=4.5.1 codecov>=2.0.15
       script:

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -1,51 +1,52 @@
 Testing
 =======
 
-Tests have been set up within the ``numpy.testing`` framework. 
+Tests have been set up within the ``numpy.testing`` framework,
+and require the ``pytest`` package to be installed.
 To launch tests, invoke ``sdepy.test()`` or ``sdepy.test('full')``.
 
-The testing subpackage ``sdepy.tests`` was written in pursuit of 
+The testing subpackage ``sdepy.tests`` was written in pursuit of
 the following goals:
 
 -  Maximize *case* coverage, by exposing the package functions and methods
-   to a plurality of different input shapes, values, data types etc., 
+   to a plurality of different input shapes, values, data types etc.,
    and of different combinations thereof, as may be encountered in practice.
 
 -  Provide a quantitative validation of the algorithms, functions and
    processes covered in ``sdepy``.
-   
--  Keep dependencies of the test code on the adopted testing framework 
+
+-  Keep dependencies of the test code on the adopted testing framework
    to a bare minimum.
-   
-Most often, a number of testing cases is declared as a list or lists of 
+
+Most often, a number of testing cases is declared as a list or lists of
 classes and inputs, a general testing procedure is set up, and
-the latter is iteratively applied to the former. Unfortunately, 
+the latter is iteratively applied to the former. Unfortunately,
 all this resulted in a thinly documented (if at all), hard to read, and hard
 to maintain testing code base - sorry about that.
 
 The quantitative validation of the package, via tests marked as ``'slow'`` and
 ``'quant'``, is done in two steps:
 
--  To validate a ``sdepy`` release, tests are run 
+-  To validate a ``sdepy`` release, tests are run
    with both 100 and 100000 paths against a fixed random seed.
-   Numerical integration results for the mean, standard deviation, 
-   probability distribution, and/or characteristic function are compared 
+   Numerical integration results for the mean, standard deviation,
+   probability distribution, and/or characteristic function are compared
    against their exact values computed analytically from the process
    parameters. Comparisons are then plotted and visually inspected, and
    the occasional larger than usual deviation is manually checked to be
    statistically acceptable, i.e. only so few standard deviations
-   off the mark. The plots and the average and maximum errors are recorded 
-   in png and text files located in the ``./tests/cfr`` directory, relative 
+   off the mark. The plots and the average and maximum errors are recorded
+   in png and text files located in the ``./tests/cfr`` directory, relative
    to the package home directory where ``sdepy.__file__`` is located.
-   
+
 -  Each time ``sdepy.test('full')`` is invoked, to keep testing times
    manageable and the testing procedure uninvasive, tests are run
    with 100 paths against the same fixed random seed, without plotting
    or storing results. The realized errors
    are then compared and checked against the expected errors,
-   as distributed with the package and stored in the 
+   as distributed with the package and stored in the
    ``./tests/cfr`` directory.
-   
+
 Note that the tests rely on the reproducibility of expected errors, once
 random numbers have been seeded with ``np.random.seed()``, across platforms
 and versions of Python, NumPy and SciPy.
@@ -58,10 +59,10 @@ in the future)::
 	PLOT = True
 	SAVE_ERRORS = True
 	QUANT_TEST_MODE = 'HD'
-	
+
 With these settings, tests are run with 100000 paths, and realized errors and
 plots are stored in the ``./tests/cfr`` directory. In case some tests fail,
 to carry out the whole procedure and get the failing errors and plots, set in
 the same configuration file::
-		
+
 	QUANT_TEST_FAIL = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # used by readthedocs
 # --------------------
 
-numpy >= 1.13.3
-scipy >= 1.0.0
-nose >= 1.3.7
+numpy >= 1.16.2
+scipy >= 1.2.1
+pytest >= 3.8.1
 numpydoc >= 0.7.0

--- a/runtests.py
+++ b/runtests.py
@@ -12,7 +12,7 @@ from sdepy import _config
 from sys import version as python_version
 from numpy import __version__ as numpy_version
 from scipy import __version__ as scipy_version
-from nose import __version__ as nose_version
+from pytest import __version__ as pytest_version
 
 
 # -------------------
@@ -51,7 +51,7 @@ def print_info():
     print('python version =', python_version)
     print('numpy version = ', numpy_version)
     print('scipy version = ', scipy_version)
-    print('nose version =  ', nose_version, '\n')
+    print('pytest version =  ', pytest_version, '\n')
     return 0
 
 
@@ -141,24 +141,25 @@ def run_quickguide_py():
         'quickguide',
         os.path.join(HOME_DIR, 'quickguide.py'))
     quickguide = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(quickguide)
-    return 0
+    try:
+        spec.loader.exec_module(quickguide)
+        return 0
+    except Exception:
+        return 1
 
 
 def run_fast():
     """
     Run fast tests
     """
-    res = test()
-    return len(res.errors + res.failures)
+    return int(not test())
 
 
 def run_full():
     """
     Run full tests including tests marked 'slow' and doctests
     """
-    res = test('full', doctests=True)
-    return len(res.errors + res.failures)
+    return int(not test('full', doctests=True))
 
 
 def run_insane():
@@ -171,7 +172,7 @@ def run_insane():
     res = []
 
     def run_tests(*var, **args):
-        res.append(test(*var, **args))
+        res.append(int(not test(*var, **args)))
 
     print('------------------')
     print('RUNNING FULL TESTS')
@@ -205,14 +206,13 @@ def run_insane():
     run_tests('quant or config')
 
     # summarize results
-    count_errors = sum(len(x.errors) for x in res)
-    count_failures = sum(len(x.failures) for x in res)
+    count_failures = sum(res)
 
     print('\n--------------------')
     print('FULL TESTS COMPLETED')
     print('--------------------\n')
 
-    return count_errors + count_failures + res_quickguide
+    return count_failures + res_quickguide
 
 
 # --------------------------------------

--- a/sdepy/__init__.py
+++ b/sdepy/__init__.py
@@ -97,8 +97,8 @@ from .analytical import *
 from .kfun import *
 from .shortcuts import *
 
-import numpy.testing
-test = numpy.testing.Tester().test
+from .tests.shared import _pytest_tester
+test = _pytest_tester(__name__)
 
 __version__ = '1.1.1-dev'
 

--- a/sdepy/kfun.py
+++ b/sdepy/kfun.py
@@ -289,12 +289,13 @@ def kfunc(f=None, *, nvar=None):
     --------
     Wrap ``wiener_source`` into a kfunc, named ``dw``:
 
+        >>> import numpy
         >>> from sdepy import wiener_source, kfunc
         >>> dw = kfunc(wiener_source)
 
     Instantiate ``dw`` and evaluate it (this is business as usual):
 
-        >>> my_instance = dw(paths=100, dtype=np.float32)
+        >>> my_instance = dw(paths=100, dtype=numpy.float32)
         >>> x = my_instance(t=0, dt=1)
         >>> x.shape, x.dtype
         ((100,), dtype('float32'))
@@ -329,14 +330,14 @@ def kfunc(f=None, *, nvar=None):
     Instantiate and evaluate at once (pass one or more variables
     to the class constructor):
 
-        >>> x = dw(0, 1, paths=100, dtype=np.float32)
+        >>> x = dw(0, 1, paths=100, dtype=numpy.float32)
         >>> x.shape, x.dtype
         ((100,), dtype('float32'))
 
     As long as variables are passed by name, order doesn't
     matter (omitted variables take default values, if any):
 
-        >>> x = dw(paths=100, dtype=np.float32, dt=1, t=0)
+        >>> x = dw(paths=100, dtype=numpy.float32, dt=1, t=0)
         >>> x.shape, x.dtype
         ((100,), dtype('float32'))
     """

--- a/sdepy/tests/_pytest.ini
+++ b/sdepy/tests/_pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    slow
+    quant

--- a/sdepy/tests/shared.py
+++ b/sdepy/tests/shared.py
@@ -38,7 +38,7 @@ class _pytest_tester:
 
         pytest_args = (
             list(pytest_args) +
-            ['-vvv', '--capture=no'] +
+            ['--verbose', '--capture=no'] +
             ['-c', ini_file] +
             (['-m', label] if label else []) +
             (['--doctest-modules'] if doctests else []) +

--- a/sdepy/tests/test_source.py
+++ b/sdepy/tests/test_source.py
@@ -317,11 +317,11 @@ def test_source_true_wiener():
                         assert_allclose(c[0, 1], irho(s, t0),
                                         rtol=0.02, atol=0.01)
                         assert_allclose(v, abs(s - t0), rtol=0.02, atol=0.01)
-                        print('.', sep='', end='', file=sys.stderr)
+                        print('.', sep='', end='')
                 for s1, s2 in ((4, 6), (2, 6), (2, 4),
                                (-4, -6), (-2, -6), (-2, -4)):
                     c = corr((tw(s2) - tw(s1))[i][0], tw(s1)[i][0])
                     v = np.var((tw(s2) - tw(s1))[i][0])
                     assert_allclose(c[0, 1], 0, rtol=0.02, atol=0.01)
                     assert_allclose(v, abs(s2 - s1), rtol=0.02, atol=0.01)
-                    print('.', sep='', end='', file=sys.stderr)
+                    print('.', sep='', end='')

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ if __name__ == '__main__':
             'Mac OS-X',
             'Unix',
             ],
-        test_suite='nose.collector',
         python_requires='>=3.5',
         install_requires=['numpy>=1.15.2', 'scipy>=0.19.1'],
         packages=[

--- a/setup.py
+++ b/setup.py
@@ -46,12 +46,13 @@ if __name__ == '__main__':
             ],
         test_suite='nose.collector',
         python_requires='>=3.5',
-        install_requires=['numpy>=1.11.3', 'scipy>=0.18.1', 'nose>=1.3.7'],
+        install_requires=['numpy>=1.11.3', 'scipy>=0.18.1'],
         packages=[
             'sdepy',
             'sdepy.tests',
             ],
         package_data={'sdepy': [
+            'tests/pytest.ini',
             'tests/cfr/*err_expected.txt',
             ]}
         )

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if __name__ == '__main__':
             'sdepy.tests',
             ],
         package_data={'sdepy': [
-            'tests/pytest.ini',
+            'tests/_pytest.ini',
             'tests/cfr/*err_expected.txt',
             ]}
         )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
             ],
         test_suite='nose.collector',
         python_requires='>=3.5',
-        install_requires=['numpy>=1.11.3', 'scipy>=0.18.1'],
+        install_requires=['numpy>=1.15.2', 'scipy>=0.19.1'],
         packages=[
             'sdepy',
             'sdepy.tests',


### PR DESCRIPTION
- The sdepy.test object is now an instance of the sdepy.tests.shared._pytest_tester class, invoking pytest.main().
- The testing framework is no longer stated as a package dependency (in contrast to the former nose dependency).
- .travis.yml and runtests.py are updated accordingly.
- Bug fixed in doctests of the sdepy.kfun submodule.
