### PR TITLE
Upgrade to current NumPy random numbers generation framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - name: Fast python 3.5 tests with minimal requirements
-            py: 3.5
+          - name: Fast python 3.6 tests with minimal requirements
+            py: 3.6
             dependencies: numpy==1.15.2 scipy==0.19.1 pytest==3.8.1
             fast: true
             full: false

--- a/doc/quickguide.rst
+++ b/doc/quickguide.rst
@@ -65,7 +65,6 @@ It is best explained by examples, involving ``my_process``, ``myp`` and
 1. **Scalar process** in 100000 paths, with default parameters, computed
    at 5 time points (``coarse_timeline``), using 100 steps in between::
 
-    >>> np.random.seed(1)  # make doctests predictable
     >>> x = my_process(x0=1, paths=100*1000,
     ...                steps=100)(coarse_timeline)
     >>> x.shape
@@ -168,7 +167,7 @@ It is best explained by examples, involving ``my_process``, ``myp`` and
     >>> for i in range(10):
     ...     gr = plt.plot(k[0, :, 0], x[-1, i, :, :].mean(axis=-1))
     >>> lb = plt.xlabel('k'), plt.ylabel('x(t=2).mean()')
-    >>> plt.show() # doctest: +SKIP
+    >>> plt.show()  # doctest: +SKIP
 
    In the example above, set ``steps>=100`` to go from inaccurate and fast,
    to meaningful and slow.
@@ -292,7 +291,7 @@ It is best explained by examples, involving ``my_process``, ``myp`` and
     >>> gr = plt.plot(t, x1(t)[:, i], t, x2(t)[:, i], t, x3(t)[:, i])
     >>> plt.show() # doctest: +SKIP
     >>> gr = plt.plot(t, y1[:, i], t, y2[:, i], t, y3[:, i])
-    >>> plt.show() # doctest: +SKIP
+    >>> plt.show()  # doctest: +SKIP
 
 
 ------------------------------------
@@ -504,7 +503,6 @@ an exact result irrespective of the number and size
 of the integration steps (this happens since, by implementation,
 it integrates the linear SDE for ``log(x)``)::
 
-    >>> np.random.seed(1)
     >>> args = dict(dw=sdepy.true_wiener_source(paths=100),
     ...             paths=100, x0=10)
     >>> timeline = (0, 1)
@@ -524,7 +522,8 @@ it integrates the linear SDE for ``log(x)``)::
     >>> ax = plt.axes(label=0); ax.set_xscale('log'); ax.set_yscale('log')
     >>> gr = ax.plot(steps, errors)
     >>> plt.show()  # doctest: +SKIP
-    >>> print('euler error: {:.2e}\n   rk error: {:.2e}'.format(errors[-1,0], errors[-1,1]))
+    >>> print(f'euler error: {errors[-1,0]:.2e}\n'
+    ...       f'   rk error: {errors[-1,1]:.2e}')  # doctest: +SKIP
     euler error: 1.70e-03
        rk error: 8.80e-06
 
@@ -547,7 +546,6 @@ Setup::
     >>> from scipy.special import erf
     >>> from scipy.integrate import quad
 
-    >>> np.random.seed(1)
     >>> k = .5
     >>> x0, x1 = 0, 10;
     >>> t0, t1 = 0, 1
@@ -608,9 +606,9 @@ Comparison against exact values::
     >>> gr = plt.plot(xgrid, u2, y, u2_exact(y, t1), ':')
     >>> plt.show()  # doctest: +SKIP
 
-    >>> print('u1 error: {:.2e}\nu2 error: {:.2e}'.format(
-    ...     np.abs(u1 - u1_exact(xgrid, t1)).mean(),
-    ...     np.abs(u2 - u2_exact(xgrid, t1)).mean()))
+    >>> print(f'u1 error: {np.abs(u1 - u1_exact(xgrid, t1)).mean():.2e}\n'
+    ...       f'u2 error: {np.abs(u2 - u2_exact(xgrid, t1)).mean():.2e}'
+    ... )  # doctest: +SKIP
     u1 error: 2.49e-03
     u2 error: 5.51e-03
 
@@ -653,7 +651,6 @@ simulated across 50000 independent paths and their antithetics
     ...     mu=(riskfree - dividend_yield),
     ...     sigma=sigma,
     ...     vshape=4, paths=100*1000, steps=maturity*250)
-    >>> np.random.seed(1)
     >>> x = p(timeline)
     >>> x.shape
     (9, 4, 100000)

--- a/sdepy/tests/shared.py
+++ b/sdepy/tests/shared.py
@@ -110,7 +110,8 @@ KFUNC = _config.KFUNC
 # (see eps function below)
 EPS_FACTOR = 16
 
-# each testing routine should call np.random.seed(SEED) or legacy_seed(SEED)
+# each testing routine should call legacy_seed(SEED) and
+# access random numbers via rng().random, rng().normal etc.
 SEED = 1234
 
 # DIR is the directory used, in quantitative tests,
@@ -166,6 +167,12 @@ def legacy_seed(seed):
         sdepy.infrastructure.default_rng = np.random.RandomState(seed)
     # uncomment this to test using PCG64:
     # sdepy.infrastructure.default_rng = np.random.default_rng(seed)
+
+
+def rng():
+    """Use `rng()` instead of `np.random` to access the current
+    sdepy default random number generator."""
+    return sdepy.infrastructure.default_rng
 
 
 def do(testing_function, *case_iterators, **args):

--- a/sdepy/tests/test_analytical.py
+++ b/sdepy/tests/test_analytical.py
@@ -135,7 +135,7 @@ def test_warnings():
 
 
 def test_analytical():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     # all functions excluding hw2f stats
     # ----------------------------------
@@ -217,7 +217,7 @@ def analytical(f, tshape, xushape, params_shape, nvar, hw2f):
 
     # generate variables and parameters values
     def make(shape):
-        return 0.1*np.random.random(shape)
+        return 0.1*rng().random(shape)
     t = 1 + make(tshape)
     xu = 1 + make(xushape)
     if hw2f:

--- a/sdepy/tests/test_integrator.py
+++ b/sdepy/tests/test_integrator.py
@@ -61,7 +61,7 @@ class generator_cls(paths_generator):
 
 # tests with output timeline == integration timeline
 def test_generator_t():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     integr = generator_cls(paths=1, vshape=(), xw0=1)
     t = np.linspace(0, 10, 11)
@@ -113,7 +113,7 @@ def test_generator_t():
 
 # tests with output timeline != integration timeline
 def test_generator_steps():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     integr = generator_cls(paths=1, vshape=(), xw0=1,
                            info={})
@@ -168,7 +168,7 @@ class deep_cls(paths_generator):
 
 def test_generator_depth():
 
-    np.random.seed(SEED)
+    legacy_seed(SEED)
     integr = deep_cls(dtype=int)
     x = integr((1, 2, 3))
     assert_((x == np.array((10, 20, 30)).reshape(-1, 1)).all())
@@ -183,7 +183,7 @@ def test_generator_depth():
 # ------------------------------
 
 def test_SDE():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     paths = 3
     vshapes = ((), 2, (2, 5))
@@ -370,7 +370,7 @@ def test_SDE():
     # -------------------------------------
     def f(t, x=0, y=0, z=0, w=0):
         return ({'dw': x}, {'dw': y}, {'dw': z}, {'dw': w})
-    rm4 = np.random.random((4, 4))
+    rm4 = rng().random((4, 4))
     corr4 = np.eye(4) + 0.1 * (rm4 + rm4.T)
     xs = integrate(f)(x0=(1,)*4, corr=corr4, paths=11, steps=30)(t)
     for u in xs:

--- a/sdepy/tests/test_kfunc.py
+++ b/sdepy/tests/test_kfunc.py
@@ -273,7 +273,7 @@ def test_kfunc_params():
 
     for X in (sp.wiener_source, sp.dw):
         assert_(kf(X)(paths=2).params ==
-                {'paths': 2, 'vshape': (), 'dtype': None,
+                {'paths': 2, 'vshape': (), 'dtype': None, 'rng': None,
                  'corr': None, 'rho': None})
 
     for X in (sp.odd_wiener_source, sp.odd_dw):
@@ -284,14 +284,14 @@ def test_kfunc_params():
 
     for X in (sp.true_wiener_source, sp.true_dw):
         assert_(kf(X)(paths=2).params ==
-                {'paths': 2, 'vshape': (), 'dtype': None,
+                {'paths': 2, 'vshape': (), 'dtype': None, 'rng': None,
                  'rtol': 'max', 't0': 0., 'z0': 0.,
                 'corr': None, 'rho': None})
 
     for X in (sp.poisson_source, sp.dn):
         assert_(kf(X)(lam=2, dtype=np.float32).params ==
                 {'paths': 1, 'vshape': (),
-                 'dtype': np.float32, 'lam': 2})
+                 'dtype': np.float32, 'rng': None, 'lam': 2})
 
     # processes
     # ---------

--- a/sdepy/tests/test_kfunc.py
+++ b/sdepy/tests/test_kfunc.py
@@ -277,10 +277,10 @@ def test_kfunc_params():
                  'corr': None, 'rho': None})
 
     for X in (sp.odd_wiener_source, sp.odd_dw):
-        # defaults beyond paths and vshape are missed
+        # defaults beyond paths, vshape, dtype, rng are missed
         # due to _antithetics wrapping
         assert_(kf(X)(paths=2).params ==
-                {'paths': 2, 'vshape': ()})
+                {'paths': 2, 'vshape': (), 'dtype': None, 'rng': None})
 
     for X in (sp.true_wiener_source, sp.true_dw):
         assert_(kf(X)(paths=2).params ==
@@ -298,7 +298,7 @@ def test_kfunc_params():
 
     for X in (sp.wiener_process, sp.wiener):
         assert_(kf(X)(x0=2).params ==
-                {'paths': 1, 'vshape': (), 'dtype': None,
+                {'paths': 1, 'vshape': (), 'dtype': None, 'rng': None,
                  'steps': None, 'i0': 0, 'info': None,
                  'getinfo': True, 'method': 'euler',
                  'dw': None, 'corr': None, 'rho': None,
@@ -306,7 +306,7 @@ def test_kfunc_params():
 
     for X in (sp.lognorm_process, sp.lognorm):
         assert_(kf(X)(x0=2).params ==
-                {'paths': 1, 'vshape': (), 'dtype': None,
+                {'paths': 1, 'vshape': (), 'dtype': None, 'rng': None,
                  'steps': None, 'i0': 0, 'info': None,
                  'getinfo': True, 'method': 'euler',
                  'dw': None, 'corr': None, 'rho': None,
@@ -314,7 +314,7 @@ def test_kfunc_params():
 
     for X in (sp.ornstein_uhlenbeck_process, sp.oruh):
         assert_(kf(X)(theta=2, steps=20).params ==
-                {'paths': 1, 'vshape': (), 'dtype': None,
+                {'paths': 1, 'vshape': (), 'dtype': None, 'rng': None,
                  'steps': 20, 'i0': 0, 'info': None,
                  'getinfo': True, 'method': 'euler', 'theta': 2,
                  'dw': None, 'corr': None, 'rho': None,
@@ -322,7 +322,7 @@ def test_kfunc_params():
 
     for X in (sp.hull_white_process, sp.hwff):
         assert_(kf(X)(vshape=3, factors=2).params ==
-                {'paths': 1, 'vshape': 3, 'dtype': None,
+                {'paths': 1, 'vshape': 3, 'dtype': None, 'rng': None,
                  'steps': None, 'i0': 0, 'info': None,
                  'getinfo': True, 'method': 'euler', 'theta': 0,
                  'dw': None, 'corr': None, 'rho': None,
@@ -331,7 +331,7 @@ def test_kfunc_params():
 
     for X in (sp.hull_white_1factor_process, sp.hw1f):
         assert_(kf(X)(vshape=3).params ==
-                {'paths': 1, 'vshape': 3, 'dtype': None,
+                {'paths': 1, 'vshape': 3, 'dtype': None, 'rng': None,
                  'steps': None, 'i0': 0, 'info': None,
                  'getinfo': True, 'method': 'euler', 'theta': 0.,
                  'dw': None, 'corr': None, 'rho': None,
@@ -339,7 +339,7 @@ def test_kfunc_params():
 
     for X in (sp.cox_ingersoll_ross_process, sp.cir):
         assert_(kf(X)(vshape=3).params ==
-                {'paths': 1, 'vshape': 3, 'dtype': None,
+                {'paths': 1, 'vshape': 3, 'dtype': None, 'rng': None,
                  'steps': None, 'i0': 0, 'info': None,
                  'getinfo': True, 'method': 'euler',
                  'dw': None, 'corr': None, 'rho': None,
@@ -348,7 +348,7 @@ def test_kfunc_params():
     for X in (sp.heston_process, sp.heston,
               sp.full_heston_process, sp.heston_xy):
         assert_(kf(X)(vshape=2).params ==
-                {'paths': 1, 'vshape': 2, 'dtype': None,
+                {'paths': 1, 'vshape': 2, 'dtype': None, 'rng': None,
                  'steps': None, 'i0': 0, 'info': None,
                  'getinfo': True, 'method': 'euler',
                  'dw': None, 'corr': None, 'rho': None,
@@ -357,7 +357,7 @@ def test_kfunc_params():
 
     for X in (sp.jumpdiff_process, sp.jumpdiff):
         assert_(kf(X)(vshape=2).params ==
-                {'paths': 1, 'vshape': 2, 'dtype': None,
+                {'paths': 1, 'vshape': 2, 'dtype': None, 'rng': None,
                  'steps': None, 'i0': 0, 'info': None,
                  'getinfo': True, 'method': 'euler', 'ptype': int,
                  'dw': None, 'corr': None, 'rho': None,
@@ -366,7 +366,7 @@ def test_kfunc_params():
 
     for X in (sp.merton_jumpdiff_process, sp.mjd):
         assert_(kf(X)(vshape=2).params ==
-                {'paths': 1, 'vshape': 2, 'dtype': None,
+                {'paths': 1, 'vshape': 2, 'dtype': None, 'rng': None,
                  'steps': None, 'i0': 0, 'info': None,
                  'getinfo': True, 'method': 'euler', 'ptype': int,
                  'dw': None, 'corr': None, 'rho': None,
@@ -375,7 +375,7 @@ def test_kfunc_params():
 
     for X in (sp.kou_jumpdiff_process, sp.kou):
         assert_(kf(X)(vshape=2).params ==
-                {'paths': 1, 'vshape': 2, 'dtype': None,
+                {'paths': 1, 'vshape': 2, 'dtype': None, 'rng': None,
                  'steps': None, 'i0': 0, 'info': None,
                  'getinfo': True, 'method': 'euler', 'ptype': int,
                  'dw': None, 'corr': None, 'rho': None,

--- a/sdepy/tests/test_montecarlo.py
+++ b/sdepy/tests/test_montecarlo.py
@@ -54,8 +54,8 @@ def montecarlo_workflow(shape, paths, dtype):
     a = montecarlo(bins='auto')
     assert_raises(ValueError, a.histogram)
     for i in range(10):
-        sample = np.random.normal(size=shape + (PATHS,)).astype(dtype)
-        sample *= (1+np.arange(size)).reshape(shape + (1,))
+        sample = (100*np.random.normal(size=shape + (PATHS,))).astype(dtype)
+        sample *= (1 + np.arange(size)).reshape(shape + (1,))
         a.update(sample)
     assert_(a.paths == PATHS*10)
 
@@ -63,7 +63,7 @@ def montecarlo_workflow(shape, paths, dtype):
     str(a)
     x = np.linspace(-3*size, 3*size, 100)
     for k in range(5):
-        i = choice(indexes)
+        i = (indexes)[-1]
         a[i].pdf(x)  # default
         a[i].pdf(x, bandwidth=.7)  # gaussian kde with explicit bandwidth
         a[i].pdf(x, kind='linear', method='interp')

--- a/sdepy/tests/test_montecarlo.py
+++ b/sdepy/tests/test_montecarlo.py
@@ -33,7 +33,7 @@ test_aaa_config.config = True
 
 # main test
 def test_montecarlo_workflow():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     # do cases
     shape = [(), (2,), (3, 2)]
@@ -54,7 +54,7 @@ def montecarlo_workflow(shape, paths, dtype):
     a = montecarlo(bins='auto')
     assert_raises(ValueError, a.histogram)
     for i in range(10):
-        sample = (100*np.random.normal(size=shape + (PATHS,))).astype(dtype)
+        sample = (100*rng().normal(size=shape + (PATHS,))).astype(dtype)
         sample *= (1 + np.arange(size)).reshape(shape + (1,))
         a.update(sample)
     assert_(a.paths == PATHS*10)
@@ -115,7 +115,7 @@ def montecarlo_workflow(shape, paths, dtype):
     # use paths along different axes
     e = None
     for k in range(len(shape)):
-        axis_sample = np.random.normal(
+        axis_sample = rng().normal(
             size=shape[:k] + (PATHS,) + shape[k:]).astype(dtype)
         # first run
         e = montecarlo(axis_sample, axis=k, bins=20, range=(-3, 3))
@@ -133,7 +133,7 @@ def montecarlo_workflow(shape, paths, dtype):
                     rtol=eps(f.mean().dtype))
 
     # antithetic sampling
-    sample = np.random.normal(size=(2*PATHS,) + shape)
+    sample = rng().normal(size=(2*PATHS,) + shape)
     even = montecarlo(sample, axis=0, use='even')
     odd = montecarlo(sample, axis=0, use='odd')
     for a in (even, odd):
@@ -141,7 +141,7 @@ def montecarlo_workflow(shape, paths, dtype):
         assert_(a.paths == PATHS)
     assert_allclose(even.mean(), montecarlo(sample, 0).mean())
     assert_allclose(odd.mean(), (sample[:PATHS]-sample[PATHS:]).mean(axis=0)/2)
-    sample2 = np.random.normal(size=(4*PATHS,) + shape)
+    sample2 = rng().normal(size=(4*PATHS,) + shape)
     even.update(sample2, axis=0)
     odd.update(sample2, axis=0)
     for a in (even, odd):
@@ -168,7 +168,7 @@ def montecarlo_workflow(shape, paths, dtype):
 
 # main test
 def test_montecarlo_cumulate():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     shape = [(), (2,), (3, 2)]
     paths = [1, 10]
@@ -180,7 +180,7 @@ def test_montecarlo_cumulate():
 # cases
 def montecarlo_cumulate(shape, paths, dtype):
     PATHS = paths
-    sample = np.random.normal(size=shape + (4*PATHS,)).astype(dtype)
+    sample = rng().normal(size=shape + (4*PATHS,)).astype(dtype)
 
     # full sample as first run
     a = montecarlo(sample)
@@ -220,7 +220,7 @@ def montecarlo_cumulate(shape, paths, dtype):
 @slow
 @quant
 def test_montecarlo_histogram():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     context = 'histogram'
     err_expected = load_errors(context)
@@ -277,7 +277,7 @@ def montecarlo_histogram(context, test_id, err_expected, err_realized,
     dist, support, bins, _ = dist_info[test_id]
     test_key = context + '_' + test_id
 
-    sample = dist.rvs(size=shape + (paths,))
+    sample = dist.rvs(size=shape + (paths,), random_state=rng())
     sample_bins = np.empty(shape + bins.shape)
     for i in np.ndindex(shape):
         sample_bins[i] = bins
@@ -335,7 +335,7 @@ def montecarlo_histogram(context, test_id, err_expected, err_realized,
 @slow
 @quant
 def test_montecarlo_dist():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     context = 'distr'
     err_expected = load_errors(context)
@@ -394,7 +394,7 @@ def montecarlo_dist(context, test_id, err_expected, err_realized,
     test_key = context + '_' + test_id
 
     # prepare sample
-    sample = dist.rvs(size=shape + (paths,))
+    sample = dist.rvs(size=shape + (paths,), random_state=rng())
     sample_bins = np.empty(shape + bins.shape)
     for i in np.ndindex(shape):
         sample_bins[i] = bins

--- a/sdepy/tests/test_process.py
+++ b/sdepy/tests/test_process.py
@@ -20,7 +20,7 @@ def test_import():
 
 # enumerate test cases and launch tests
 def test_constructor():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     # do cases
     t = [2., (5.,), (0, 1.), np.linspace(0., 4., 12)]
@@ -45,7 +45,7 @@ def process_constructor(t, paths, vshape, dtype):
         tt = tt.reshape(1)
 
     # x constructor
-    x = np.random.random(tt.shape + vshape + (paths,))
+    x = rng().random(tt.shape + vshape + (paths,))
     p = process(t, x=x, dtype=dtype)
     assert_array_equal(p.t, tt)
     assert_(isinstance(p.t, np.ndarray))
@@ -54,7 +54,7 @@ def process_constructor(t, paths, vshape, dtype):
     assert_(p.dtype == np.dtype(dtype))
 
     # v constructor
-    v = np.random.random(tt.shape + vshape)
+    v = rng().random(tt.shape + vshape)
     p = process(t, v=v, dtype=dtype)
     assert_array_equal(p.t, tt)
     assert_(isinstance(p.t, np.ndarray))
@@ -63,7 +63,7 @@ def process_constructor(t, paths, vshape, dtype):
     assert_(p.dtype == np.dtype(dtype))
 
     # c constructor
-    c = np.random.random(vshape)
+    c = rng().random(vshape)
     p = process(t, c=c, dtype=dtype)
     assert_array_equal(p.t, tt)
     assert_(isinstance(p.t, np.ndarray))
@@ -98,7 +98,7 @@ def process_constructor(t, paths, vshape, dtype):
 
 # enumerate test cases and launch tests
 def test_broadcasting():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     # do cases
     t = [np.linspace(0., 4., 12)]
@@ -110,9 +110,9 @@ def test_broadcasting():
 
 # case testing
 def process_broadcasting(t, paths, vshape):
-    p = process(t, x=np.random.random(t.shape + vshape + (paths,)))
+    p = process(t, x=rng().random(t.shape + vshape + (paths,)))
     q = process(t.copy(),
-                x=np.random.random(t.shape + vshape + (paths,)))
+                x=rng().random(t.shape + vshape + (paths,)))
 
     # same processes
     a1 = p + q
@@ -195,7 +195,7 @@ def process_broadcasting(t, paths, vshape):
 
 # enumerate test cases and launch tests
 def test_interp():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     # do cases on t, s, paths and vshape
     t = [2+np.zeros(1), np.linspace(1., 4., 12)]
@@ -261,7 +261,7 @@ def process_interp(t, s, paths, vshape, dtype, kind):
 
 # simple stand alone test on interpolated values
 def test_interp_values():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     # check interpolated values
     p = process(t=(1, 2, 3.), v=(1, 4, 9.))
@@ -277,7 +277,7 @@ def test_interp_values():
 
 # enumerate test cases and launch tests
 def test_t_getitem():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     # do cases
     t = [np.linspace(1., 4., 12)]
@@ -288,7 +288,7 @@ def test_t_getitem():
 
 # case testing
 def process_t_getitem(t, paths, vshape):
-    p = process(t, x=np.random.random(t.shape + vshape + (paths,)))
+    p = process(t, x=rng().random(t.shape + vshape + (paths,)))
 
     def verify(q, newt, newx):
         assert_(isinstance(q, process))
@@ -321,7 +321,7 @@ def process_t_getitem(t, paths, vshape):
 
 # enumerate test cases and launch tests
 def test_p_getitem():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     # do cases
     t = [np.zeros(1) + 2, np.linspace(1., 4., 12)]
@@ -332,7 +332,7 @@ def test_p_getitem():
 
 # case testing
 def process_p_getitem(t, paths, vshape):
-    p = process(t, x=np.random.random(t.shape + vshape + (paths,)))
+    p = process(t, x=rng().random(t.shape + vshape + (paths,)))
 
     def verify(q, newt, newx):
         assert_(isinstance(q, process))
@@ -368,7 +368,7 @@ def process_p_getitem(t, paths, vshape):
 
 # enumerate test cases and launch tests
 def test_v_getitem():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     # do cases
     t = [np.zeros(1) + 2, np.linspace(1., 4., 11)]
@@ -389,7 +389,7 @@ def process_v_getitem(t, paths):
             verify(p[('v',) + i], p.t, p[(slice(None),) + i + (slice(None),)])
 
     # vshape = ()
-    p = process(t, x=np.random.random(t.shape + () + (paths,)))
+    p = process(t, x=rng().random(t.shape + () + (paths,)))
     q = p['v', ()]
     verify(q, p.t, p)
     iall(p)
@@ -399,7 +399,7 @@ def process_v_getitem(t, paths):
     assert_raises(IndexError, ierr)
 
     # vshape = (5,)
-    p = process(t, x=np.random.random(t.shape + (5,) + (paths,)))
+    p = process(t, x=rng().random(t.shape + (5,) + (paths,)))
     iall(p)
     q = p['v', 0:2]
     verify(q, p.t, p[:, 0:2, :])
@@ -420,7 +420,7 @@ def process_v_getitem(t, paths):
     verify(q, p.t, p[:, i, :])
 
     # vshape = (5, 7)
-    p = process(t, x=np.random.random(t.shape + (5, 7) + (paths,)))
+    p = process(t, x=rng().random(t.shape + (5, 7) + (paths,)))
     iall(p)
     q = p['v', 0:2]
     verify(q, p.t, p[:, 0:2, :])
@@ -463,8 +463,8 @@ def process_v_getitem(t, paths):
 
 # enumerate test cases and launch tests
 def test_properties():
-    np.random.seed(SEED)
-    p = process(t=(1., 2, 4), x=np.random.random((3, 5, 7, 11)))
+    legacy_seed(SEED)
+    p = process(t=(1., 2, 4), x=rng().random((3, 5, 7, 11)))
 
     def sharemem(a, b):
         return a.__array_interface__['data'][0] == \
@@ -498,7 +498,7 @@ def process_properties(t, paths, vshape, dtype):
     if tt.ndim == 0:
         tt = tt.reshape(1)
 
-    p = process(t, x=np.random.random(tt.shape + vshape + (paths,)),
+    p = process(t, x=rng().random(tt.shape + vshape + (paths,)),
                 dtype=dtype)
     assert_(p.shape == p.t.shape + p.vshape + (p.paths,))
     assert_array_equal(p.t, p.tx.flatten())
@@ -517,10 +517,10 @@ def process_properties(t, paths, vshape, dtype):
 # ----------------
 
 def test_shapeas():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     def mkp(vshape):
-        return process(t=(0, 1), x=np.random.random((2,) + vshape + (3,)))
+        return process(t=(0, 1), x=rng().random((2,) + vshape + (3,)))
 
     for vshape in ((), (5,), (5, 7)):
         p = mkp(vshape)
@@ -555,9 +555,9 @@ def test_shapeas():
 # ----------------
 
 def test_copy():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
-    p = process(t=(1, 2, 3), x=np.random.random((3, 5, 7, 11)))
+    p = process(t=(1, 2, 3), x=rng().random((3, 5, 7, 11)))
     q = p.pcopy()
     qt = p.tcopy()
     qx = p.xcopy()
@@ -581,9 +581,9 @@ def test_copy():
 # -----------------------
 
 def test_summary():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
-    p = process(t=(1, 2, 3), x=1 + np.random.random((3, 5, 7, 11)),
+    p = process(t=(1, 2, 3), x=1 + rng().random((3, 5, 7, 11)),
                 dtype=np.float64)
 
     funcs = ('min', 'max', 'sum', 'mean', 'var', 'std')
@@ -686,11 +686,11 @@ def test_summary():
 # ----------------------------------------
 
 def test_increments():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     t = np.linspace(1, 2, 100)
     t *= t
-    p = process(t, x=1 + np.random.random(t.shape + (2, 3) + (5,)),
+    p = process(t, x=1 + rng().random(t.shape + (2, 3) + (5,)),
                 dtype=np.float64)
 
     dp = p.tdiff()
@@ -727,7 +727,7 @@ def test_increments():
 
 # enumerate test cases and launch tests
 def test_chf_cdf():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     t = [2., (5.,), (0, 1.), np.linspace(0., 4., 17)]
     paths = [1, 19]
@@ -744,7 +744,7 @@ def process_chf_cdf(t, s, u, paths, vshape):
         tt = tt.reshape(1)
     ss, uu = np.asarray(s), np.asarray(u)
 
-    p = process(t, x=np.random.random(tt.shape + vshape + (paths,)))
+    p = process(t, x=rng().random(tt.shape + vshape + (paths,)))
 
     f = p.chf(u)
     assert_(f.shape == tt.shape + uu.shape + vshape)
@@ -775,7 +775,7 @@ def process_chf_cdf(t, s, u, paths, vshape):
 
 # enumerate test cases and launch tests
 def test_piecewise():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     dtype = [np.float64, np.float32, np.float16]
     paths = [None, 5]
@@ -797,11 +797,11 @@ def tst_piecewise(dtype, paths, vshape, mode, shift):
     t = np.array((1, 2, 3), dtype=dtype) + shift
     if paths is None:
         paths = 1
-        v = vv = 1 + np.random.random((3,) + vshape).astype(dtype)
+        v = vv = 1 + rng().random((3,) + vshape).astype(dtype)
         x = v.reshape(v.shape + (1,))
         xx = None
     else:
-        x = xx = 1 + np.random.random((3,) + vshape + (paths,)).astype(dtype)
+        x = xx = 1 + rng().random((3,) + vshape + (paths,)).astype(dtype)
         vv = None
 
     if mode is None:

--- a/sdepy/tests/test_process.py
+++ b/sdepy/tests/test_process.py
@@ -782,7 +782,7 @@ def test_piecewise():
     vshape = [(3,), (2, 3)]
     mode = [None, 'mid', 'forward', 'backward']
     shift = [0, -2, -4]
-    do(tst_piecewise, [np.float], paths, vshape, mode, shift)
+    do(tst_piecewise, [float], paths, vshape, mode, shift)
     do(tst_piecewise,      dtype, paths,   [()], mode,   [0])
 
     with assert_raises(ValueError):

--- a/sdepy/tests/test_processes.py
+++ b/sdepy/tests/test_processes.py
@@ -97,11 +97,14 @@ def test_processes():
                          )(np.linspace(0, 1, 100))
 
     # a 'bare' object with source protocol
-    def S2(s, ds):
-        return rng().normal(size=(2, 11))*sqrt(np.abs(ds))
-
-    S2.vshape = (2,)
-    S2.paths = 11
+    def make_S2(rng_):
+        if rng_ is None:
+            rng_ = rng()
+        def S2(s, ds):
+            return rng_.normal(size=(2, 11))*sqrt(np.abs(ds))
+        S2.vshape = (2,)
+        S2.paths = 11
+        return S2
 
     # a generic scipy random variable
     rv = scipy.stats.trapz(c=.1, d=.2)
@@ -119,9 +122,10 @@ def test_processes():
     do(processes, cls, params, paths, dtype)
 
     paths, dtype = [11], [None]
-    params = (dict(vshape=2, dw=Z2),
-              dict(vshape=2, dw=S2),
-              )
+    params = (
+        dict(vshape=2, dw=Z2),
+        lambda rng=None: dict(vshape=2, dw=make_S2(rng)),
+    )
     cls = list(cls)
     for p in (heston_process, heston,
               full_heston_process, heston_xy,
@@ -142,8 +146,10 @@ def test_processes():
         dict(vshape=(2,), corr=CM2),
         dict(vshape=(2, 3)),
         dict(vshape=(2, 3), corr=CM3),
-        dict(vshape=(2, 3), dw=wiener_source(paths=11, vshape=(2, 3))),
-        dict(vshape=(), dw=true_wiener_source(paths=11, vshape=())),
+        lambda rng=None: dict(
+            vshape=(2, 3), dw=wiener_source(paths=11, vshape=(2, 3), rng=rng)),
+        lambda rng=None: dict(
+            vshape=(), dw=true_wiener_source(paths=11, vshape=(), rng=rng)),
         dict(vshape=(2, 3), dw=Z23),
         )
     do(processes, cls, params, paths, dtype)
@@ -153,9 +159,11 @@ def test_processes():
         dict(vshape=2, x0=.1, theta=.2, k=.4, sigma=.5),
         dict(vshape=(2,), corr=CM2),
         dict(vshape=(2,), dw=Z2),
-        dict(vshape=(2, 3), dw=wiener_source(paths=11, vshape=(2, 3))),
+        lambda rng=None: dict(
+            vshape=(2, 3), dw=wiener_source(paths=11, vshape=(2, 3), rng=rng)),
         dict(vshape=(2, 3), dw=Z23),
-        dict(vshape=(), dw=true_wiener_source(paths=11, vshape=()))
+        lambda rng=None: dict(
+            vshape=(), dw=true_wiener_source(paths=11, vshape=(), rng=rng))
     )
     do(processes, cls, params, paths, dtype)
 
@@ -166,25 +174,28 @@ def test_processes():
         dict(vshape=(), factors=2,
              x0=((.1,), (.2,)), theta=((.4,), (.5,)), k=((.6,), (.7,)),
              sigma=((.8,), (.9,)), rho=0.25),
-        dict(vshape=(), factors=2,
-             dw=wiener_source(paths=11, vshape=(2,),
-                              corr=((1, .25,), (.25, 1)))),
+        lambda rng=None: dict(
+            vshape=(), factors=2,
+            dw=wiener_source(paths=11, vshape=(2,), rng=rng,
+                             corr=((1, .25,), (.25, 1)))),
         dict(vshape=(3,), factors=2, dw=Z32),
-        dict(vshape=(), factors=3,
-             dw=wiener_source(paths=11, vshape=(3,), corr=CM3)),
+        lambda rng=None: dict(vshape=(), factors=3,
+             dw=wiener_source(paths=11, vshape=(3,), corr=CM3, rng=rng)),
         dict(vshape=(2, 3), factors=5,
              sigma=np.arange(2*3*5).reshape(2, 3, 5, 1)/(300)),
         dict(vshape=2, factors=3, dw=Z23),
         dict(vshape=(), factors=2, dw=Z2),
-        dict(vshape=(), factors=2, dw=S2),
+        lambda rng=None: dict(vshape=(), factors=2, dw=make_S2(rng)),
     )
     do(processes, cls, params, paths, dtype)
 
     cls = (hull_white_1factor_process, hw1f)
     params = (
         dict(vshape=2, x0=.1, theta=.2, k=.4, sigma=.5),
-        dict(vshape=(2, 3), dw=wiener_source(paths=11, vshape=(2, 3))),
-        dict(vshape=(), dw=true_wiener_source(paths=11, vshape=())),
+        lambda rng=None: dict(
+            vshape=(2, 3), dw=wiener_source(paths=11, vshape=(2, 3), rng=rng)),
+        lambda rng=None: dict(
+            vshape=(), dw=true_wiener_source(paths=11, vshape=(), rng=rng)),
     )
     do(processes, cls, params, paths, dtype)
 
@@ -193,8 +204,10 @@ def test_processes():
         dict(vshape=2, x0=.1, theta=.2, k=.3, xi=.4),
         dict(vshape=(2,), corr=CM2),
         dict(vshape=(2,), rho=-.1),
-        dict(vshape=(2, 3), dw=wiener_source(paths=11, vshape=(2, 3))),
-        dict(vshape=(), dw=true_wiener_source(paths=11, vshape=())),
+        lambda rng=None: dict(
+            vshape=(2, 3), dw=wiener_source(paths=11, vshape=(2, 3), rng=rng)),
+        lambda rng=None: dict(
+            vshape=(), dw=true_wiener_source(paths=11, vshape=(), rng=rng)),
         dict(vshape=(2, 3), dw=Z23)
     )
     do(processes, cls, params, paths, dtype)
@@ -208,10 +221,12 @@ def test_processes():
              y0=.4, theta=.5, k=.6, xi=.7),
         dict(vshape=(3,), corr=CM6),
         dict(vshape=(3,), rho=(.1, .2, .3)),
-        dict(vshape=(5,), dw=wiener_source(paths=11, vshape=(10,))),
-        dict(vshape=10, dw=true_wiener_source(paths=11, vshape=(20,))),
+        lambda rng=None: dict(
+            vshape=(5,), dw=wiener_source(paths=11, vshape=(10,), rng=rng)),
+        lambda rng=None: dict(
+            vshape=10, dw=true_wiener_source(paths=11, vshape=(20,), rng=rng)),
         dict(vshape=(), dw=Z2),
-        dict(vshape=(), dw=S2),
+        lambda rng=None: dict(vshape=(), dw=make_S2(rng)),
     )
     do(processes, cls, params, paths, dtype)
 
@@ -229,11 +244,12 @@ def test_processes():
         dict(vshape=(), corr=CM2),
         dict(vshape=(1,), corr=CM2),
         dict(vshape=(2, 3, 1), rho=.25),
-        dict(vshape=(3), dw=wiener_source(paths=11, vshape=(6,))),
-        dict(vshape=(2, 3, 1),
-             dw=true_wiener_source(paths=11, vshape=(2, 3, 2))),
+        lambda rng=None: dict(
+            vshape=(3), dw=wiener_source(paths=11, vshape=(6,), rng=rng)),
+        lambda rng=None: dict(vshape=(2, 3, 1),
+            dw=true_wiener_source(paths=11, vshape=(2, 3, 2), rng=rng)),
         dict(vshape=(), dw=Z2),
-        dict(vshape=(), dw=S2),
+        lambda rng=None: dict(vshape=(), dw=make_S2(rng)),
     )
     do(processes, cls, params, paths, dtype)
 
@@ -245,17 +261,24 @@ def test_processes():
         dict(vshape=2, x0=.1, mu=.2, sigma=.3,
              lam=.4),
         dict(vshape=(2,), corr=CM2),
-        dict(vshape=(2, 3), dw=wiener_source(paths=11, vshape=(2, 3))),
-        dict(vshape=(3,), dw=true_wiener_source(paths=11, vshape=(3,)),
-             dj=cpoisson_source(paths=11, vshape=(3,))),
-        dict(vshape=(3,), dw=true_wiener_source(paths=11, vshape=(3,)),
-             dj=true_cpoisson_source(paths=11, vshape=(3,))),
-        dict(vshape=2, dj=poisson_source(paths=11, vshape=2)),
-        dict(vshape=2, dj=true_poisson_source(paths=11, vshape=2)),
-        dict(vshape=2, dj=cpoisson_source(paths=11, vshape=2, y=rv)),
-        dict(vshape=2, dj=true_cpoisson_source(paths=11, vshape=2, y=rv)),
+        lambda rng=None: dict(
+            vshape=(2, 3), dw=wiener_source(paths=11, vshape=(2, 3), rng=rng)),
+        lambda rng=None: dict(
+            vshape=(3,), dw=true_wiener_source(paths=11, vshape=(3,), rng=rng),
+            dj=cpoisson_source(paths=11, vshape=(3,), rng=rng)),
+        lambda rng=None: dict(
+            vshape=(3,), dw=true_wiener_source(paths=11, vshape=(3,), rng=rng),
+            dj=true_cpoisson_source(paths=11, vshape=(3,), rng=rng)),
+        lambda rng=None: dict(
+            vshape=2, dj=poisson_source(paths=11, vshape=2, rng=rng)),
+        lambda rng=None: dict(
+            vshape=2, dj=true_poisson_source(paths=11, vshape=2, rng=rng)),
+        lambda rng=None: dict(
+            vshape=2, dj=cpoisson_source(paths=11, vshape=2, y=rv, rng=rng)),
+        lambda rng=None: dict(
+            vshape=2, dj=true_cpoisson_source(paths=11, vshape=2, y=rv, rng=rng)),
         dict(vshape=2, dw=Z2, dj=Z2),
-        dict(vshape=2, dw=S2, dj=S2),
+        lambda rng=None: dict(vshape=2, dw=make_S2(rng), dj=make_S2(rng)),
     )
     do(processes, cls, params, paths, dtype)
 
@@ -304,9 +327,14 @@ def test_processes_local():
 
     def CM2(t): return ((1, .2*t/10), (.2*t/10, 1))
 
-    def CM6(t):
-        C = np.eye(6) + t*0.1*rng().random((6, 6))
-        return (C + C.T)/2
+    rng_ = rng()
+    def make_CM6(rng_):
+        if rng_ is None:
+            rng_ = rng()
+        def CM6(t):
+            C = np.eye(6) + t*0.1*rng_.random((6, 6))
+            return (C + C.T)/2
+        return CM6
 
     def R(t): return 0.5 - 0.1*t
 
@@ -325,19 +353,21 @@ def test_processes_local():
         dict(vshape=(2,), mu=A, sigma=C, corr=CM2P),
         dict(vshape=(2,), mu=A, sigma=C, rho=R),
         dict(vshape=(2,), mu=A, sigma=C, rho=RP),
-        dict(vshape=(6,), mu=A, sigma=C, corr=CM6),
+        lambda rng=None: dict(vshape=(6,), mu=A, sigma=C, corr=make_CM6(rng)),
         dict(vshape=(6,), mu=A, sigma=C, rho=R3P),
-        dict(vshape=(6,), mu=A, sigma=C,
-             dw=true_wiener_source(paths=11, vshape=6, rho=R3P)),
-        )
+        lambda rng=None: dict(
+            vshape=(6,), mu=A, sigma=C,
+            dw=true_wiener_source(paths=11, vshape=6, rho=R3P, rng=rng)),
+    )
     do(processes, cls, params, paths, dtype)
 
     cls = (ornstein_uhlenbeck_process, )
     params = (
         dict(vshape=(), x0=.1, theta=A, k=B, sigma=C),
         dict(vshape=(2,), theta=A, k=B, sigma=C, corr=CM2),
-        dict(vshape=(2,), theta=A, k=B, sigma=C,
-             dw=true_wiener_source(paths=11, vshape=2, corr=CM2)),
+        lambda rng=None: dict(
+            vshape=(2,), theta=A, k=B, sigma=C,
+            dw=true_wiener_source(paths=11, vshape=2, corr=CM2, rng=rng)),
     )
     do(processes, cls, params, paths, dtype)
 
@@ -360,7 +390,8 @@ def test_processes_local():
     params = (
         dict(vshape=(), x0=.1, mu=A, sigma=B,
              y0=.2, theta=C, k=B, xi=A, rho=B),
-        dict(vshape=(3,), theta=A, k=B, xi=C, corr=CM6),
+        lambda rng=None: dict(
+            vshape=(3,), theta=A, k=B, xi=C, corr=make_CM6(rng)),
         dict(vshape=(3,), theta=A, k=B, xi=C, rho=R3P)
     )
     do(processes, cls, params, paths, dtype)
@@ -369,7 +400,8 @@ def test_processes_local():
     params = (
         dict(vshape=(), x0=.1, mu=A, sigma=B,
              y0=.2, theta=A, k=B, xi=C, rho=B),
-        dict(vshape=(3,), theta=A, k=B, xi=C, corr=CM6)
+        lambda rng=None: dict(
+            vshape=(3,), theta=A, k=B, xi=C, corr=make_CM6(rng))
     )
     do(processes, cls, params, paths, dtype)
 
@@ -401,6 +433,12 @@ def test_processes_local():
 
 # case testing
 def processes(cls, params, paths, dtype):
+
+    # store params maker to be used for rng tests
+    make_params = params
+    if callable(make_params):
+        # recover params with default rng for other tests
+        params = make_params()
 
     # print(cls.__name__, sep='', end='')
     P = cls(**params, paths=paths, dtype=dtype)
@@ -437,6 +475,43 @@ def processes(cls, params, paths, dtype):
                     # initial values are the same for all paths
                     assert_((p[i0] == p[i0, ..., 0][..., np.newaxis]).all())
 
+                # extensive test of rng parameter (too slow to be included
+                # in the test suite)
+                if False:
+                    try:
+                        make_rngs = (
+                            np.random.default_rng,
+                            np.random.RandomState,
+                            lambda z: np.random.Generator(
+                                np.random.PCG64(z)),
+                        )
+                    except AttributeError:
+                        continue
+                    for make_rng in make_rngs:
+                        rng1 = make_rng(SEED)
+                        rng2 = make_rng(SEED)
+                        assert rng1 is not rng2
+                        if callable(make_params):
+                            params1 = make_params(rng1)
+                            params2 = make_params(rng2)
+                        else:
+                            params1 = params2 = params
+                        P1 = cls(**params1, paths=paths,
+                                 dtype=dtype, rng=rng1,
+                                 steps=steps, i0=i0)
+                        P2 = cls(**params2, paths=paths,
+                                 dtype=dtype, rng=rng2,
+                                 steps=steps, i0=i0)
+                        assert P1.rng is rng1
+                        assert P2.rng is rng2
+                        ps1, ps2 = P1(t), P2(t)
+                        ps1, ps2 = [
+                            ps if isinstance(ps, (tuple, list)) else (ps,)
+                            for ps in (ps1, ps2)]
+                        assert len(ps1) == len(ps2)
+                        for z, w in zip(ps1, ps2):
+                            assert_allclose(z, w)
+
     # check initial conditions on the last computed p
     if cls in {wiener_process, lognorm_process,
                ornstein_uhlenbeck_process,
@@ -464,6 +539,51 @@ def processes(cls, params, paths, dtype):
         q0, y0 = np.broadcast_arrays(q[i0], P.args['y0'])
         assert_allclose(p0, x0, rtol=eps(p.dtype))
         assert_allclose(q0, y0, rtol=eps(p.dtype))
+
+    # test rng parameter
+    try:
+        make_rngs = (
+            np.random.default_rng,
+            np.random.RandomState,
+            lambda z: np.random.Generator(np.random.PCG64(z)),
+        )
+    except AttributeError:
+        return
+    for make_rng in make_rngs:
+        rng1 = make_rng(SEED)
+        rng2 = make_rng(SEED)
+        assert rng1 is not rng2
+        if callable(make_params):
+            params1 = make_params(rng1)
+            params2 = make_params(rng2)
+        else:
+            params1 = params2 = params
+        t = tlist[-1]
+        P1 = cls(**params1, paths=paths, dtype=dtype, rng=rng1)
+        P2 = cls(**params2, paths=paths, dtype=dtype, rng=rng2)
+        assert P1.rng is rng1
+        assert P2.rng is rng2
+        ps1, ps2 = P1(t), P2(t)
+        ps1, ps2 = [ps if isinstance(ps, (tuple, list)) else (ps,)
+                    for ps in (ps1, ps2)]
+        assert len(ps1) == len(ps2)
+        for z, w in zip(ps1, ps2):
+            assert_allclose(z, w)
+        # test that global sdepy.infrastructure.default_rng
+        # propagates correctly as a default
+        tmp = sdepy.infrastructure.default_rng
+        sdepy.infrastructure.default_rng = make_rng(SEED)
+        if callable(make_params):
+            params3 = make_params()
+        else:
+            params3 = params
+        P3 = cls(**params3, paths=paths, dtype=dtype, rng=None)
+        assert P3.rng is sdepy.infrastructure.default_rng
+        ps3 = P3(t)
+        ps3 = ps3 if isinstance(ps3, (tuple, list)) else (ps3,)
+        assert len(ps1) == len(ps3)
+        assert_allclose(ps1, ps3)
+        sdepy.infrastructure.default_rng = tmp
 
 
 # stand alone test

--- a/sdepy/tests/test_processes.py
+++ b/sdepy/tests/test_processes.py
@@ -79,13 +79,13 @@ all_shortcuts = (wiener, lognorm,
 # enumerate test cases with constant parameters and launch tests
 # --------------------------------------------------------------
 def test_processes():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     # setup some parameter test values
     # --------------------------------
     CM2 = ((1, .2), (.2, 1))
     CM3 = ((1, .2, -.3), (.2, 1, .1), (-.3, .1, 1))
-    CM6 = np.eye(6) + 0.1*np.random.random((6, 6))
+    CM6 = np.eye(6) + 0.1*rng().random((6, 6))
     CM6 = (CM6 + CM6.T)/2
 
     # processes to act as sources
@@ -98,7 +98,7 @@ def test_processes():
 
     # a 'bare' object with source protocol
     def S2(s, ds):
-        return np.random.normal(size=(2, 11))*sqrt(np.abs(ds))
+        return rng().normal(size=(2, 11))*sqrt(np.abs(ds))
 
     S2.vshape = (2,)
     S2.paths = 11
@@ -287,7 +287,7 @@ def test_processes():
 # enumerate test cases with time-dependent parameters and launch tests
 # --------------------------------------------------------------------
 def test_processes_local():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     # setup some parameter test values
     # --------------------------------
@@ -305,7 +305,7 @@ def test_processes_local():
     def CM2(t): return ((1, .2*t/10), (.2*t/10, 1))
 
     def CM6(t):
-        C = np.eye(6) + t*0.1*np.random.random((6, 6))
+        C = np.eye(6) + t*0.1*rng().random((6, 6))
         return (C + C.T)/2
 
     def R(t): return 0.5 - 0.1*t
@@ -476,7 +476,7 @@ def test_processes_exceptions():
 
 
 def test_jumps():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     # jump diffusion process integrated as is
     # (jumpdiff_process integrates the logarithm)
@@ -550,7 +550,7 @@ def test_processes_misc():
     # test exactness of wiener_process and lognorm_process
     # with constant parameters
 
-    np.random.seed(SEED)
+    legacy_seed(SEED)
     paths = 31
     x0 = 10
     mu, sigma = .2, .7

--- a/sdepy/tests/test_quant.py
+++ b/sdepy/tests/test_quant.py
@@ -296,7 +296,7 @@ def quant_case(case, context, err_expected, err_realized, PATHS):
     # plot paths for visual inspection (no testing)
     if PLOT:
         print('plotting...')
-        np.random.seed(SEED)
+        legacy_seed(SEED)
         fig = bfig()
         plt.title('{}: 30 sample paths'.format(Xid))
         plt.xlabel('t')
@@ -306,7 +306,7 @@ def quant_case(case, context, err_expected, err_realized, PATHS):
 
     # check mean, std and variance
     if Xmean is not None:
-        np.random.seed(SEED)
+        legacy_seed(SEED)
         x = X(t, paths=PATHS)
         if 'heston' in Xid:
             log(x, out=x)
@@ -323,7 +323,7 @@ def quant_case(case, context, err_expected, err_realized, PATHS):
         del x
 
     # check pdf and cdf
-    np.random.seed(SEED)
+    legacy_seed(SEED)
     a = sp.montecarlo(bins=200)
     for i in range(10):
         x = X(s, paths=PATHS)
@@ -533,7 +533,7 @@ def params_case(case, context, err_expected, err_realized, PATHS):
         pvalues = args[param]
 
     # process to be tested
-    np.random.seed(SEED)
+    legacy_seed(SEED)
     if iskfunc(Xclass):
         # test kfunc call with parameters
         x = Xclass(**args)(s, paths=PATHS)
@@ -587,7 +587,7 @@ def params_case(case, context, err_expected, err_realized, PATHS):
 
 def test_bs():
     """a bare-bone test on Black-Scholes call and put valuation"""
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     Kc, Kp = 1.2, 0.6
     T = 2.

--- a/sdepy/tests/test_source.py
+++ b/sdepy/tests/test_source.py
@@ -45,7 +45,7 @@ true_wiener_source = sp.true_wiener_source
 
 # main test
 def test_source_general():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     # do cases
     paths = [10]
@@ -201,7 +201,7 @@ def source_general(paths, dtype, source_and_params):
 
 # main test
 def test_source_specific():
-    np.random.seed(SEED)
+    legacy_seed(SEED)
 
     # wiener tests
     src = wiener_source(vshape=3, paths=5)
@@ -316,7 +316,7 @@ def test_source_true_wiener():
     rho2, irho2 = (lambda t: 0.1 + t/6, lambda t, t0: 0.1 + (t + t0)/12)
     rho3, irho3 = (None, lambda t, t0: 0)
 
-    np.random.seed(SEED)
+    legacy_seed(SEED)
     for t0 in (0, 1):
         for rho, irho in ((rho0, irho0), (rho1, irho1),
                           (rho2, irho2), (rho3, irho3)):

--- a/sdepy/tests/test_source.py
+++ b/sdepy/tests/test_source.py
@@ -226,7 +226,7 @@ def test_source_specific():
     val = 2.
 
     class const_rv:
-        def rvs(self, size):
+        def rvs(self, size, random_state):
             return np.full(size, fill_value=val)
 
     src = cpoisson_source(lam=1., paths=100, ptype=np.int16,
@@ -235,6 +235,21 @@ def test_source_specific():
     assert_allclose(n*val, s, rtol=eps(s.dtype))
     s, n = src(0, 100), src.dn_value
     assert_allclose(n*val, s, rtol=eps(s.dtype))
+
+    # compound poisson tests with legacy rv signature
+    val = 2.
+
+    class const_rv_legacy:
+        def rvs(self, size):
+            return np.full(size, fill_value=val)
+
+    src = cpoisson_source(lam=1., paths=100, ptype=np.int16,
+                              y=const_rv_legacy())
+    with assert_warns(DeprecationWarning):
+        s, n = src(0, 1), src.dn_value
+        assert_allclose(n*val, s, rtol=eps(s.dtype))
+        s, n = src(0, 100), src.dn_value
+        assert_allclose(n*val, s, rtol=eps(s.dtype))
 
     # true sources tests
     for cls in (true_wiener_source, true_poisson_source, true_cpoisson_source,


### PR DESCRIPTION
- Delegate default random number generation to a global `np.random.default_rng()` object, created upon import.
- Add an `rng` optional keyword argument to SDEs and stochasticity source classes, accepting  any `np.random.Generator` or `np.random.RandomState` instance, to locally override the default random number generator.
- Keep legacy default behavior reproducible, in current numpy versions, via the assignment `sdepy.infrastructure.default_rng = np.random.RandomState(SEED)` in place of the `np.random.seed(SEED)` statement. Any other use of such global variable should rather be avoided, in favor of using the `rng` keyword.
- Safeguard backward compatibility with legacy numpy and sdepy versions. In such case, SDEs and sources accept only `rng=None`.

Fixes #33