### PR TITLE
Update tests for use beyond NumPy legacy random generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,15 +127,16 @@ jobs:
         run: |
           cd ./build/tests
           python runtests.py 'no_source()' \
-            "run('full', doctests=True, warnings='${{ matrix.warnings }}')"
+            "run('full', doctests=True, warnings='${{ matrix.warnings }}', rng='legacy')" \
+            "run('full', warnings='${{ matrix.warnings }}', plot=True, outdir='.', rng=lambda: np.random.default_rng(1))"
           python runtests.py 'run_quickguide()'
       - name: Run full tests with coverage
         if: ${{ matrix.full-with-coverage }}
         run: |
           cd ./build/tests
           coverage run --rcfile=../../.coveragerc \
-            runtests.py 'no_source()' \
-            "run('full', doctests=True, warnings='${{ matrix.warnings }}')"
+            "run('full', doctests=True, warnings='${{ matrix.warnings }}', rng='legacy')" \
+            "run('full', warnings='${{ matrix.warnings }}', plot=True, outdir='.', rng=lambda: np.random.default_rng(1))"
           python runtests.py 'run_quickguide()'
       - name: Upload to codecov
         if: ${{ matrix.full-with-coverage }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
         run: |
           cd ./build/tests
           coverage run --rcfile=../../.coveragerc \
+            runtests.py 'no_source()' \
             "run('full', doctests=True, warnings='${{ matrix.warnings }}', rng='legacy')" \
             "run('full', warnings='${{ matrix.warnings }}', plot=True, outdir='.', rng=lambda: np.random.default_rng(1))"
           python runtests.py 'run_quickguide()'

--- a/runtests.py
+++ b/runtests.py
@@ -5,6 +5,7 @@ import importlib
 import doctest
 import pdb
 
+import numpy as np
 import sdepy
 from sdepy import test
 from sdepy import _config
@@ -137,16 +138,12 @@ def run_quickguide():
         ).failed
 
 
-def run(label='fast', doctests=False, warnings='pass'):
+def run(*args, **kws):
     """
     Run tests with given options
     """
     print_info()
-    pytest_args = {'pass': (),
-                   'fail': ('-W', 'error::Warning')}
-    return int(not test(
-        label=label, doctests=doctests,
-        pytest_args=pytest_args[warnings]))
+    return int(not test(*args, **kws))
 
 
 def run_insane(warnings='pass'):
@@ -171,24 +168,20 @@ def run_insane(warnings='pass'):
 
     # run tests with maximum code coverage, in all
     # kfunc modes
-    _config.PLOT = True
-    _config.OUTPUT_DIR = TEST_DIR
-    _config.VERBOSE = True
-    _config.PATHS = 100
     for k in ('shortcuts', 'all', None):
         _config.KFUNC = k
         reload()
-        results.append(run('full', doctests=True, warnings=warnings))
+        results.append(run('full', doctests=True, warnings=warnings,
+                           plot=True, outdir=TEST_DIR, verbose=1,
+                           paths=100))
 
     # run quantitative tests with high resolution
     # and maximum code coverage
-    _config.PLOT = True
-    _config.OUTPUT_DIR = TEST_DIR
-    _config.VERBOSE = True
-    _config.PATHS = 100_000
     _config.KFUNC = None
     reload()
-    results.append(run('quant or config', warnings=warnings))
+    results.append(run('quant or config', warnings=warnings,
+                       plot=True, outdir=TEST_DIR, verbose=1,
+                       paths=100_000))
 
     # summarize results
     count_failures = sum(results)

--- a/runtests.py
+++ b/runtests.py
@@ -172,9 +172,9 @@ def run_insane(warnings='pass'):
     # run tests with maximum code coverage, in all
     # kfunc modes
     _config.PLOT = True
-    _config.SAVE_ERRORS = True
+    _config.OUTPUT_DIR = TEST_DIR
     _config.VERBOSE = True
-    _config.QUANT_TEST_MODE = 'LD'
+    _config.PATHS = 100
     for k in ('shortcuts', 'all', None):
         _config.KFUNC = k
         reload()
@@ -183,9 +183,9 @@ def run_insane(warnings='pass'):
     # run quantitative tests with high resolution
     # and maximum code coverage
     _config.PLOT = True
-    _config.SAVE_ERRORS = True
+    _config.OUTPUT_DIR = TEST_DIR
     _config.VERBOSE = True
-    _config.QUANT_TEST_MODE = 'HD'
+    _config.PATHS = 100_000
     _config.KFUNC = None
     reload()
     results.append(run('quant or config', warnings=warnings))

--- a/sdepy/_config.py
+++ b/sdepy/_config.py
@@ -29,7 +29,7 @@ VERBOSE = False
 
 # random number generator, or function returning a
 # properly seeded such generator, to be used in tests;
-# if set to 'legacy', use numpy legacy random number generation,
+# if set to 'legacy', use numpy legacy random generation,
 # and check expected vs. realized errors, failing if found
 # inconsistent
 TEST_RNG = 'legacy'

--- a/sdepy/_config.py
+++ b/sdepy/_config.py
@@ -9,11 +9,33 @@ Global settings for:
 """
 
 # kfunc deployment (see .shortcuts)
+# ---------------------------------
 KFUNC = 'shortcuts'
 
-# testing (see .tests.shared)
+
+# testing mode
+# ------------
+
+# if False, quantitative tests do not execute plot construction;
+# if True, needs matplotlib.pyplot to be installed
 PLOT = False
-SAVE_ERRORS = False
+
+# if OUTPUT_DIR is not None, quantitative tests save
+# in this folder the realized errors and, if generated,
+# plot images.
+OUTPUT_DIR = None
+
 VERBOSE = False
-QUANT_TEST_MODE = 'LD'
-QUANT_TEST_FAIL = True
+
+# random number generator, or function returning a
+# properly seeded such generator, to be used in tests;
+# if set to 'legacy', use numpy legacy random number generation,
+# and check expected vs. realized errors, failing if found
+# inconsistent
+TEST_RNG = 'legacy'
+
+# number of paths generated while executing quantitative tests;
+# .tests.test_montecarlo quant tests cumulate 100*PATHS paths
+# .tests.test_quant geterates processes with PATH paths,
+# using order of 100 steps (the actual number of steps depends on the process)
+PATHS = 100

--- a/sdepy/tests/shared.py
+++ b/sdepy/tests/shared.py
@@ -290,16 +290,17 @@ def load_errors(context, dtype=float):
         return noerrors_expected
 
 
-def save_errors(context, errors):
+def save_errors(context, errors,
+                item1='MEAN_ERROR', item2='MAX_ERROR'):
     DIR = sdepy._config.OUTPUT_DIR
     if DIR is not None:
         fname = os.path.join(DIR, context + '_err_realized.txt')
         with open(fname, 'w') as f:
             print('{:40} {:>12} {:>12}\n'.format(
-                'TEST_ID', 'MEAN_ERROR', 'MAX_ERROR'), file=f)
-            for test_key, (mean_error, max_error) in errors.items():
+                'TEST_ID', item1, item2), file=f)
+            for test_key, (err1, err2) in errors.items():
                 print('{:40s} {:12.5g} {:12.5g}'.format(
-                    test_key, mean_error, max_error), file=f)
+                    test_key, err1, err2), file=f)
 
 
 def save_figure(fig, fig_id):

--- a/sdepy/tests/test_analytical.py
+++ b/sdepy/tests/test_analytical.py
@@ -135,7 +135,7 @@ def test_warnings():
 
 
 def test_analytical():
-    legacy_seed(SEED)
+    rng_setup()
 
     # all functions excluding hw2f stats
     # ----------------------------------

--- a/sdepy/tests/test_integrator.py
+++ b/sdepy/tests/test_integrator.py
@@ -61,7 +61,7 @@ class generator_cls(paths_generator):
 
 # tests with output timeline == integration timeline
 def test_generator_t():
-    legacy_seed(SEED)
+    rng_setup()
 
     integr = generator_cls(paths=1, vshape=(), xw0=1)
     t = np.linspace(0, 10, 11)
@@ -113,7 +113,7 @@ def test_generator_t():
 
 # tests with output timeline != integration timeline
 def test_generator_steps():
-    legacy_seed(SEED)
+    rng_setup()
 
     integr = generator_cls(paths=1, vshape=(), xw0=1,
                            info={})
@@ -168,7 +168,7 @@ class deep_cls(paths_generator):
 
 def test_generator_depth():
 
-    legacy_seed(SEED)
+    rng_setup()
     integr = deep_cls(dtype=int)
     x = integr((1, 2, 3))
     assert_((x == np.array((10, 20, 30)).reshape(-1, 1)).all())
@@ -183,7 +183,7 @@ def test_generator_depth():
 # ------------------------------
 
 def test_SDE():
-    legacy_seed(SEED)
+    rng_setup()
 
     paths = 3
     vshapes = ((), 2, (2, 5))

--- a/sdepy/tests/test_kfunc.py
+++ b/sdepy/tests/test_kfunc.py
@@ -10,17 +10,11 @@ iskfunc = sp.iskfunc
 
 def test_aaa_config():
     """testall.py: print realized configuration"""
-    if VERBOSE:
+    if sdepy._config.VERBOSE:
         print('\n****', __name__, 'configuration:')
         print('KFUNC, iskfunc(wiener), iskfunc(wiener_process) =',
-              KFUNC, sp.iskfunc(sp.wiener), sp.iskfunc(sp.wiener_process))
-        print('PLOT, SAVE_ERRORS =',
-              PLOT, SAVE_ERRORS)
-        print('VERBOSE, QUANT_TEST_MODE =',
-              VERBOSE, QUANT_TEST_MODE)
-
-
-test_aaa_config.config = True
+              sdepy._config.KFUNC, sp.iskfunc(sp.wiener),
+              sp.iskfunc(sp.wiener_process))
 
 
 # -----------

--- a/sdepy/tests/test_process.py
+++ b/sdepy/tests/test_process.py
@@ -20,7 +20,7 @@ def test_import():
 
 # enumerate test cases and launch tests
 def test_constructor():
-    legacy_seed(SEED)
+    rng_setup()
 
     # do cases
     t = [2., (5.,), (0, 1.), np.linspace(0., 4., 12)]
@@ -98,7 +98,7 @@ def process_constructor(t, paths, vshape, dtype):
 
 # enumerate test cases and launch tests
 def test_broadcasting():
-    legacy_seed(SEED)
+    rng_setup()
 
     # do cases
     t = [np.linspace(0., 4., 12)]
@@ -195,7 +195,7 @@ def process_broadcasting(t, paths, vshape):
 
 # enumerate test cases and launch tests
 def test_interp():
-    legacy_seed(SEED)
+    rng_setup()
 
     # do cases on t, s, paths and vshape
     t = [2+np.zeros(1), np.linspace(1., 4., 12)]
@@ -261,7 +261,7 @@ def process_interp(t, s, paths, vshape, dtype, kind):
 
 # simple stand alone test on interpolated values
 def test_interp_values():
-    legacy_seed(SEED)
+    rng_setup()
 
     # check interpolated values
     p = process(t=(1, 2, 3.), v=(1, 4, 9.))
@@ -277,7 +277,7 @@ def test_interp_values():
 
 # enumerate test cases and launch tests
 def test_t_getitem():
-    legacy_seed(SEED)
+    rng_setup()
 
     # do cases
     t = [np.linspace(1., 4., 12)]
@@ -321,7 +321,7 @@ def process_t_getitem(t, paths, vshape):
 
 # enumerate test cases and launch tests
 def test_p_getitem():
-    legacy_seed(SEED)
+    rng_setup()
 
     # do cases
     t = [np.zeros(1) + 2, np.linspace(1., 4., 12)]
@@ -368,7 +368,7 @@ def process_p_getitem(t, paths, vshape):
 
 # enumerate test cases and launch tests
 def test_v_getitem():
-    legacy_seed(SEED)
+    rng_setup()
 
     # do cases
     t = [np.zeros(1) + 2, np.linspace(1., 4., 11)]
@@ -463,7 +463,7 @@ def process_v_getitem(t, paths):
 
 # enumerate test cases and launch tests
 def test_properties():
-    legacy_seed(SEED)
+    rng_setup()
     p = process(t=(1., 2, 4), x=rng().random((3, 5, 7, 11)))
 
     def sharemem(a, b):
@@ -517,7 +517,7 @@ def process_properties(t, paths, vshape, dtype):
 # ----------------
 
 def test_shapeas():
-    legacy_seed(SEED)
+    rng_setup()
 
     def mkp(vshape):
         return process(t=(0, 1), x=rng().random((2,) + vshape + (3,)))
@@ -555,7 +555,7 @@ def test_shapeas():
 # ----------------
 
 def test_copy():
-    legacy_seed(SEED)
+    rng_setup()
 
     p = process(t=(1, 2, 3), x=rng().random((3, 5, 7, 11)))
     q = p.pcopy()
@@ -581,7 +581,7 @@ def test_copy():
 # -----------------------
 
 def test_summary():
-    legacy_seed(SEED)
+    rng_setup()
 
     p = process(t=(1, 2, 3), x=1 + rng().random((3, 5, 7, 11)),
                 dtype=np.float64)
@@ -686,7 +686,7 @@ def test_summary():
 # ----------------------------------------
 
 def test_increments():
-    legacy_seed(SEED)
+    rng_setup()
 
     t = np.linspace(1, 2, 100)
     t *= t
@@ -727,7 +727,7 @@ def test_increments():
 
 # enumerate test cases and launch tests
 def test_chf_cdf():
-    legacy_seed(SEED)
+    rng_setup()
 
     t = [2., (5.,), (0, 1.), np.linspace(0., 4., 17)]
     paths = [1, 19]
@@ -775,7 +775,7 @@ def process_chf_cdf(t, s, u, paths, vshape):
 
 # enumerate test cases and launch tests
 def test_piecewise():
-    legacy_seed(SEED)
+    rng_setup()
 
     dtype = [np.float64, np.float32, np.float16]
     paths = [None, 5]

--- a/sdepy/tests/test_processes.py
+++ b/sdepy/tests/test_processes.py
@@ -79,7 +79,7 @@ all_shortcuts = (wiener, lognorm,
 # enumerate test cases with constant parameters and launch tests
 # --------------------------------------------------------------
 def test_processes():
-    legacy_seed(SEED)
+    rng_setup()
 
     # setup some parameter test values
     # --------------------------------
@@ -310,7 +310,7 @@ def test_processes():
 # enumerate test cases with time-dependent parameters and launch tests
 # --------------------------------------------------------------------
 def test_processes_local():
-    legacy_seed(SEED)
+    rng_setup()
 
     # setup some parameter test values
     # --------------------------------
@@ -487,6 +487,7 @@ def processes(cls, params, paths, dtype):
                         )
                     except AttributeError:
                         continue
+                    SEED = 1234
                     for make_rng in make_rngs:
                         rng1 = make_rng(SEED)
                         rng2 = make_rng(SEED)
@@ -549,6 +550,7 @@ def processes(cls, params, paths, dtype):
         )
     except AttributeError:
         return
+    SEED = 1234
     for make_rng in make_rngs:
         rng1 = make_rng(SEED)
         rng2 = make_rng(SEED)
@@ -596,7 +598,7 @@ def test_processes_exceptions():
 
 
 def test_jumps():
-    legacy_seed(SEED)
+    rng_setup()
 
     # jump diffusion process integrated as is
     # (jumpdiff_process integrates the logarithm)
@@ -670,7 +672,7 @@ def test_processes_misc():
     # test exactness of wiener_process and lognorm_process
     # with constant parameters
 
-    legacy_seed(SEED)
+    rng_setup()
     paths = 31
     x0 = 10
     mu, sigma = .2, .7

--- a/sdepy/tests/test_quant.py
+++ b/sdepy/tests/test_quant.py
@@ -72,10 +72,8 @@ def check_values(context, Xid, t, *tests,
         mean_err = delta.mean()
         max_err = delta.max()
         if sdepy._config.VERBOSE:
-            print('{:45}{:10.6f} {:10.6f}'
-                  .format(key + ' (mean err)', mean_err, err_expected[key][0]))
-            print('{:45}{:10.6f} {:10.6f}'
-                  .format(key + ' (max err)', max_err, err_expected[key][1]))
+            print(f'{key + " (mean err, max err)":50}'
+                  f'{mean_err:10.6f} {max_err:10.6f}')
         assert_quant(mean_err < err_expected[key][0])
         assert_quant(max_err < err_expected[key][1])
         err_realized[key] = (mean_err, max_err)

--- a/sdepy/tests/test_quant.py
+++ b/sdepy/tests/test_quant.py
@@ -3,10 +3,9 @@
 QUANTITATIVE (SLOW) TESTS ON REALIZED PROCESSES
 ===============================================
 
-PATHS_HD or PATHS_LD paths are computed for each
-process, according to the QUANT_TEST_MODE flag
-(see 'shared.py' module), on a timeline of 50 points,
-using 50 or 200 integration steps dependant on the process type.
+sdepy._config.PATHS paths are computed for each
+process, on a timeline of 50 points, using 50 or 200
+integration steps dependant on the process type.
 
 Tests on pdf and cdf labeled 'pdf' and 'cdf1'
 cumulate 10 runs using update, pdf and cdf methods
@@ -21,19 +20,14 @@ from numpy import exp, log
 iskfunc = sp.iskfunc
 
 
+@quant
 def test_aaa_config():
     """testall.py: print realized configuration"""
-    if VERBOSE:
+    if sdepy._config.VERBOSE:
         print('\n****', __name__, 'configuration:')
-        print('KFUNC, iskfunc(wiener), iskfunc(wiener_process) =',
-              KFUNC, sp.iskfunc(sp.wiener), sp.iskfunc(sp.wiener_process))
-        print('PLOT, SAVE_ERRORS =',
-              PLOT, SAVE_ERRORS)
-        print('VERBOSE, QUANT_TEST_MODE =',
-              VERBOSE, QUANT_TEST_MODE)
-
-
-test_aaa_config.config = True
+        print('PLOT, PATHS =',
+              sdepy._config.PLOT, sdepy._config.PATHS)
+        print('TEST_RNG =', sdepy._config.TEST_RNG)
 
 
 # --------------------------
@@ -77,7 +71,7 @@ def check_values(context, Xid, t, *tests,
             raise ValueError('unrecognized mode')
         mean_err = delta.mean()
         max_err = delta.max()
-        if VERBOSE:
+        if sdepy._config.VERBOSE:
             print('{:45}{:10.6f} {:10.6f}'
                   .format(key + ' (mean err)', mean_err, err_expected[key][0]))
             print('{:45}{:10.6f} {:10.6f}'
@@ -87,7 +81,7 @@ def check_values(context, Xid, t, *tests,
         err_realized[key] = (mean_err, max_err)
         if brk == key:
             raise RuntimeError('a break was set at {}'.format(key))
-    if PLOT:
+    if sdepy._config.PLOT:
         print('plotting...')
         fig = bfig()
         plots = ((111,), (121, 122), (221, 222, 223,),
@@ -173,12 +167,18 @@ def hw2f_F_wrap2(F):
 @slow
 @quant
 def test_quant():
-    if QUANT_TEST_MODE == 'HD':
-        tst_quant(context='quant5', PATHS=PATHS_HD)
-    elif QUANT_TEST_MODE == 'LD':
-        tst_quant(context='quant2', PATHS=PATHS_LD)
+    PATHS = sdepy._config.PATHS
+    if sdepy._config.TEST_RNG != 'legacy':
+        tst_quant(context='quant' + str(int(PATHS)),
+                  PATHS=PATHS)
+    elif PATHS == 100_000:
+        tst_quant(context='quant5', PATHS=PATHS)
+    elif PATHS == 100:
+        tst_quant(context='quant2', PATHS=PATHS)
     else:
-        raise ValueError()
+        raise ValueError(
+            f'tests with numpy legacy rng require '
+            f'either 100 or 100_000 paths, not {PATHS}')
 
 
 def tst_quant(context, PATHS):
@@ -294,9 +294,9 @@ def quant_case(case, context, err_expected, err_realized, PATHS):
     fargs.pop('steps', None)
 
     # plot paths for visual inspection (no testing)
-    if PLOT:
+    if sdepy._config.PLOT:
         print('plotting...')
-        legacy_seed(SEED)
+        rng_setup()
         fig = bfig()
         plt.title('{}: 30 sample paths'.format(Xid))
         plt.xlabel('t')
@@ -306,7 +306,7 @@ def quant_case(case, context, err_expected, err_realized, PATHS):
 
     # check mean, std and variance
     if Xmean is not None:
-        legacy_seed(SEED)
+        rng_setup()
         x = X(t, paths=PATHS)
         if 'heston' in Xid:
             log(x, out=x)
@@ -323,7 +323,7 @@ def quant_case(case, context, err_expected, err_realized, PATHS):
         del x
 
     # check pdf and cdf
-    legacy_seed(SEED)
+    rng_setup()
     a = sp.montecarlo(bins=200)
     for i in range(10):
         x = X(s, paths=PATHS)
@@ -363,12 +363,18 @@ def quant_case(case, context, err_expected, err_realized, PATHS):
 @slow
 @quant
 def test_params():
-    if QUANT_TEST_MODE == 'HD':
-        tst_params(context='params5', PATHS=PATHS_HD)
-    elif QUANT_TEST_MODE == 'LD':
-        tst_params(context='params2', PATHS=PATHS_LD)
+    PATHS = sdepy._config.PATHS
+    if sdepy._config.TEST_RNG != 'legacy':
+        tst_params(context='params' + str(int(PATHS)),
+                   PATHS=PATHS)
+    elif PATHS == 100_000:
+        tst_params(context='params5', PATHS=PATHS)
+    elif PATHS == 100:
+        tst_params(context='params2', PATHS=PATHS)
     else:
-        raise ValueError()
+        raise ValueError(
+            f'tests with numpy legacy rng require '
+            f'either 100 or 100_000 paths, not {PATHS}')
 
 
 # main test
@@ -533,7 +539,7 @@ def params_case(case, context, err_expected, err_realized, PATHS):
         pvalues = args[param]
 
     # process to be tested
-    legacy_seed(SEED)
+    rng_setup()
     if iskfunc(Xclass):
         # test kfunc call with parameters
         x = Xclass(**args)(s, paths=PATHS)
@@ -587,7 +593,7 @@ def params_case(case, context, err_expected, err_realized, PATHS):
 
 def test_bs():
     """a bare-bone test on Black-Scholes call and put valuation"""
-    legacy_seed(SEED)
+    rng_setup()
 
     Kc, Kp = 1.2, 0.6
     T = 2.

--- a/sdepy/tests/test_source.py
+++ b/sdepy/tests/test_source.py
@@ -45,7 +45,7 @@ true_wiener_source = sp.true_wiener_source
 
 # main test
 def test_source_general():
-    legacy_seed(SEED)
+    rng_setup()
 
     # do cases
     paths = [10]
@@ -203,6 +203,7 @@ def source_general(paths, dtype, source_and_params):
         )
     except AttributeError:
         return
+    SEED = 1234
     for make_rng in make_rngs:
         rng1 = make_rng(SEED)
         rng2 = make_rng(SEED)
@@ -231,7 +232,7 @@ def source_general(paths, dtype, source_and_params):
 
 # main test
 def test_source_specific():
-    legacy_seed(SEED)
+    rng_setup()
 
     # wiener tests
     src = wiener_source(vshape=3, paths=5)
@@ -346,7 +347,7 @@ def test_source_true_wiener():
     rho2, irho2 = (lambda t: 0.1 + t/6, lambda t, t0: 0.1 + (t + t0)/12)
     rho3, irho3 = (None, lambda t, t0: 0)
 
-    legacy_seed(SEED)
+    rng_setup()
     for t0 in (0, 1):
         for rho, irho in ((rho0, irho0), (rho1, irho1),
                           (rho2, irho2), (rho3, irho3)):


### PR DESCRIPTION
- Refactor private options for tests, in `sdepy._config` and `sdepy.tests.shared`.
- Wrap in a legacy test mode (used by default), reliant on NumPy legacy random generation, all comparisons of expected vs realized errors, that pass conditional on reproducibility of random streams.
- For non legacy testing, set up optional output of realized errors and plots, as files in a user-specified directory.
- Update and extend the `sdepy.test()` interface accordingly.
- Update runtests.py and ci matrix, adding non legacy testing besides testing in legacy mode.