### PR TITLE
Fix residual issues on tests execution and reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,5 @@
 [run]
 branch = True
 source = sdepy
-
-[report]
 omit =
     *tests*

--- a/sdepy/__init__.py
+++ b/sdepy/__init__.py
@@ -129,4 +129,3 @@ if sys.version_info[:2] <= (3, 5):
     warnings.warn('The use of SdePy with Python 3.5 is deprecated '
                   'and will not be supported in future releases.',
                   DeprecationWarning)
-

--- a/sdepy/integration.py
+++ b/sdepy/integration.py
@@ -1872,7 +1872,7 @@ def _SDE_from_function(f, q=None, sources=None, log=False, addaxis=False):
             ids.update(z.keys())
         # consistency check
         if ((q is not None and neq != q) or
-            (sources is not None and set(sources) != ids)):
+                (sources is not None and set(sources) != ids)):
             raise TypeError(
                 'test evaluation of {} inconsistent with given '
                 "'q' or 'sources'".format(f))

--- a/sdepy/tests/shared.py
+++ b/sdepy/tests/shared.py
@@ -3,7 +3,9 @@
 COMMON TESTING INFRASTRUCTURE
 =============================
 """
-# common imports
+# -----------------------------------
+# shared imports used in test modules
+# -----------------------------------
 import numpy as np
 from numpy.testing import (
     assert_, assert_raises, assert_warns,
@@ -18,6 +20,19 @@ try:
     PYTEST = True
 except ImportError:
     PYTEST = False
+
+# in all test modules, 'sdeyp' or 'sp' is the package
+# to be tested
+import sdepy
+import sdepy as sp
+
+# set up plotting if required
+try:
+    import matplotlib.pyplot as plt
+    plt.rcParams['figure.figsize'] = 12, 6
+
+except ImportError:
+    pass
 
 
 # -------------
@@ -112,7 +127,7 @@ class _pytest_tester:
         user_args = (
             [] if (pytest_args is None) else
             ([pytest_args] if isinstance(pytest_args, str) else
-            list(pytest_args)))
+             list(pytest_args)))
 
         run_args = (
             warn_args + user_args +
@@ -139,28 +154,6 @@ class _pytest_tester:
         else:
             raise ImportError(
                 'sdepy.test() requires pytest to be installed')
-
-
-# ----------------------------
-# *** PACKAGE TO BE TESTED ***
-# ----------------------------
-
-# in all test modules, 'sp' is the package
-# to be tested
-import sdepy
-import sdepy as sp
-
-
-# ---------------------------
-# set up plotting if required
-# ---------------------------
-
-try:
-    import matplotlib.pyplot as plt
-    plt.rcParams['figure.figsize'] = 12, 6
-
-except ImportError:
-    pass
 
 
 # -----------------------------------
@@ -197,12 +190,14 @@ if PYTEST:
     quant = pytest.mark.quant
     # Decorator to mark test as slow
     slow = pytest.mark.slow
+    # Private decorator to set test focus
+    focus = pytest.mark.focus
 else:
     # dummy decorators in case pytest is not installed
-    quant = slow = lambda f: f
+    quant = slow = focus = lambda f: f
 
 
-def rng_setup():
+def rng_setup(force_legacy=False):
     """Use in each test to setup the sdepy default random number generator
     (replaces legacy `np.random.seed(SEED)` calls).
     """
@@ -211,7 +206,7 @@ def rng_setup():
         # running with legacy numpy versions, without np.random.RandomState:
         # fall back on numpy global state
         np.random.seed(_LEGACY_SEED)
-    elif test_rng == 'legacy':
+    elif (test_rng == 'legacy') or force_legacy:
         # test with numpy Legacy Random Generation
         sdepy.infrastructure.default_rng = (
             np.random.RandomState(_LEGACY_SEED))

--- a/sdepy/tests/test_integrator.py
+++ b/sdepy/tests/test_integrator.py
@@ -409,7 +409,7 @@ def test_SDE():
     @integrate
     def f_process(t, x):
         return {'dt': 1, 'dw': 1}
-    assert_ (issubclass(f_process, SDE))
+    assert_(issubclass(f_process, SDE))
     assert_(not issubclass(f_process, SDEs))
     x = f_process(x0=1, paths=11, steps=30)(t)
 
@@ -463,12 +463,14 @@ def test_SDE():
         return {'dt': 1}, {'dw': 1}
     xs = f_process(x0=(1,)*2, paths=11, steps=30)(t)
 
-    # test evaluation inconsistent with declared q or sources
+    # test evaluation inconsistent with declared q
     def err():
         @integrate(q=1)
         def f_process(t, x=1., y=1.):
             return {'dt': 1}, {'dw': 1}
     assert_raises(TypeError, err)
+
+    # test evaluation inconsistent with declared sources
     def err():
         @integrate(sources={'dw'})
         def f_process(t, x=1., y=1.):

--- a/sdepy/tests/test_montecarlo.py
+++ b/sdepy/tests/test_montecarlo.py
@@ -162,7 +162,7 @@ def montecarlo_workflow(shape, paths, dtype):
 # -------------
 
 # main test
-#@focus
+# @focus
 def test_montecarlo_cumulate():
     rng_setup()
 

--- a/sdepy/tests/test_montecarlo.py
+++ b/sdepy/tests/test_montecarlo.py
@@ -162,11 +162,12 @@ def montecarlo_workflow(shape, paths, dtype):
 # -------------
 
 # main test
+#@focus
 def test_montecarlo_cumulate():
     rng_setup()
 
     shape = [(), (2,), (3, 2)]
-    paths = [1, 10]
+    paths = [1, 25]
     dtype = [None, float, np.float64, np.float32, np.float16,
              int, np.int64, np.int32, np.int16]
     do(montecarlo_cumulate, shape, paths, dtype)
@@ -175,7 +176,7 @@ def test_montecarlo_cumulate():
 # cases
 def montecarlo_cumulate(shape, paths, dtype):
     PATHS = paths
-    sample = rng().normal(size=shape + (4*PATHS,)).astype(dtype)
+    sample = 1 + rng().normal(size=shape + (4*PATHS,)).astype(dtype)
 
     # full sample as first run
     a = montecarlo(sample)
@@ -184,14 +185,14 @@ def montecarlo_cumulate(shape, paths, dtype):
     b = montecarlo(sample[..., :PATHS])
     b.update(sample[..., PATHS:2*PATHS])
     b.update(sample[..., 2*PATHS:])
-
-    rtol = max(eps(sample.dtype), eps(a.mean().dtype))
-    assert_allclose(a.mean(), b.mean(), rtol=2*rtol)
-    assert_allclose(a.stderr(), b.stderr(), rtol=rtol)
-    assert_allclose(a.mean(), sample.mean(axis=-1),
-                    rtol=rtol)
-    assert_allclose(a.stderr(), sample.std(axis=-1)/np.sqrt(4*PATHS-1),
-                    rtol=rtol)
+    if PATHS > 1:
+        rtol = max(eps(sample.dtype), eps(a.mean().dtype))
+        assert_allclose(a.mean(), b.mean(), rtol=rtol)
+        assert_allclose(a.stderr(), b.stderr(), rtol=rtol)
+        assert_allclose(a.mean(), sample.mean(axis=-1),
+                        rtol=rtol)
+        assert_allclose(a.stderr(), sample.std(axis=-1)/np.sqrt(4*PATHS-1),
+                        rtol=rtol)
 
     # same sample loaded in 3 runs, using same bins
     c = montecarlo()

--- a/sdepy/tests/test_processes.py
+++ b/sdepy/tests/test_processes.py
@@ -605,7 +605,7 @@ def test_processes_exceptions():
         assert_raises(ValueError, P, np.arange(6.).reshape(2, 3))
 
 
-#@focus
+# @focus
 def test_jumps():
     rng_setup(force_legacy=True)
 

--- a/sdepy/tests/test_processes.py
+++ b/sdepy/tests/test_processes.py
@@ -100,8 +100,10 @@ def test_processes():
     def make_S2(rng_):
         if rng_ is None:
             rng_ = rng()
+
         def S2(s, ds):
             return rng_.normal(size=(2, 11))*sqrt(np.abs(ds))
+
         S2.vshape = (2,)
         S2.paths = 11
         return S2
@@ -179,8 +181,9 @@ def test_processes():
             dw=wiener_source(paths=11, vshape=(2,), rng=rng,
                              corr=((1, .25,), (.25, 1)))),
         dict(vshape=(3,), factors=2, dw=Z32),
-        lambda rng=None: dict(vshape=(), factors=3,
-             dw=wiener_source(paths=11, vshape=(3,), corr=CM3, rng=rng)),
+        lambda rng=None: dict(
+            vshape=(), factors=3,
+            dw=wiener_source(paths=11, vshape=(3,), corr=CM3, rng=rng)),
         dict(vshape=(2, 3), factors=5,
              sigma=np.arange(2*3*5).reshape(2, 3, 5, 1)/(300)),
         dict(vshape=2, factors=3, dw=Z23),
@@ -246,7 +249,8 @@ def test_processes():
         dict(vshape=(2, 3, 1), rho=.25),
         lambda rng=None: dict(
             vshape=(3), dw=wiener_source(paths=11, vshape=(6,), rng=rng)),
-        lambda rng=None: dict(vshape=(2, 3, 1),
+        lambda rng=None: dict(
+            vshape=(2, 3, 1),
             dw=true_wiener_source(paths=11, vshape=(2, 3, 2), rng=rng)),
         dict(vshape=(), dw=Z2),
         lambda rng=None: dict(vshape=(), dw=make_S2(rng)),
@@ -276,7 +280,8 @@ def test_processes():
         lambda rng=None: dict(
             vshape=2, dj=cpoisson_source(paths=11, vshape=2, y=rv, rng=rng)),
         lambda rng=None: dict(
-            vshape=2, dj=true_cpoisson_source(paths=11, vshape=2, y=rv, rng=rng)),
+            vshape=2,
+            dj=true_cpoisson_source(paths=11, vshape=2, y=rv, rng=rng)),
         dict(vshape=2, dw=Z2, dj=Z2),
         lambda rng=None: dict(vshape=2, dw=make_S2(rng), dj=make_S2(rng)),
     )
@@ -328,12 +333,15 @@ def test_processes_local():
     def CM2(t): return ((1, .2*t/10), (.2*t/10, 1))
 
     rng_ = rng()
+
     def make_CM6(rng_):
         if rng_ is None:
             rng_ = rng()
+
         def CM6(t):
             C = np.eye(6) + t*0.1*rng_.random((6, 6))
             return (C + C.T)/2
+
         return CM6
 
     def R(t): return 0.5 - 0.1*t
@@ -597,8 +605,9 @@ def test_processes_exceptions():
         assert_raises(ValueError, P, np.arange(6.).reshape(2, 3))
 
 
+#@focus
 def test_jumps():
-    rng_setup()
+    rng_setup(force_legacy=True)
 
     # jump diffusion process integrated as is
     # (jumpdiff_process integrates the logarithm)
@@ -665,6 +674,8 @@ def test_jumps():
     # print(m1, m2, s1, s2)
     assert_(abs(1-m2/m1) < 0.01)
     assert_(abs(1-s2/s1) < 0.03)
+
+    rng_setup(force_legacy=False)
 
 
 def test_processes_misc():

--- a/sdepy/tests/test_quant.py
+++ b/sdepy/tests/test_quant.py
@@ -588,6 +588,7 @@ def params_case(case, context, err_expected, err_realized, PATHS):
         check(pvalues, *tests, fig_id='cdf_chf',
               mode='abs', xlabel=param)
 
+
 @quant
 def test_bs():
     """a bare-bone test on Black-Scholes call and put valuation"""

--- a/sdepy/tests/test_source.py
+++ b/sdepy/tests/test_source.py
@@ -231,7 +231,7 @@ def source_general(paths, dtype, source_and_params):
 # ---------------------
 
 # main test
-#@focus
+# @focus
 def test_source_specific():
     rng_setup()
 

--- a/tools.py
+++ b/tools.py
@@ -95,7 +95,7 @@ def getnotebook(in_, out,
     in_, out = str(pathlib.Path(in_)), str(pathlib.Path(out))
     with open(in_) as f:
         z = list(header) + [x.rstrip() + '\n'
-             for x in f.readlines()[skip:]]
+                            for x in f.readlines()[skip:]]
 
     nb = nbf.v4.new_notebook()
     nb['cells'] = []


### PR DESCRIPTION
- Fix residual non quantitative tests that implicitly relied on stably reproducible random numbers to pass - e.g. tests assuming that a realized value does not stray beyond 2 standard deviations from its expected value, and that were bound to fail 5% of test runs when not running in legacy mode with a stable seeding.
- Fix pycodestyle.
- Exclude sdepy tests suite from coverage data reported to Codecov.
